### PR TITLE
Add Ubuntu Docker images

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,51 @@
+name: Ubuntu
+
+on:
+  push:
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+
+jobs:
+  # Build the Docker image for Ubuntu using different versions of GCC.
+  gcc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - os: jammy
+            gcc: 12
+          - os: noble
+            gcc: 14
+    steps:
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} --password-stdin
+      - name: Build the Docker image
+        run: |
+          DOCKER_BUILDKIT=1 docker build . \
+          --target gcc \
+          --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
+          --build-arg GCC_VERSION=${{ matrix.version.gcc }} \
+          --tag ${{ github.event.repository.name }}/${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}
+
+  # Build the Docker image for Ubuntu using different versions of Clang.
+  clang:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - os: noble
+            clang: 18
+          - os: noble
+            clang: 19
+    steps:
+      - name: Login to GitHub Container Registry
+        run: |
+          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.actor }} --password-stdin
+      - name: Build the Docker image
+        run: |
+          DOCKER_BUILDKIT=1 docker build . \
+          --target clang \
+          --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
+          --build-arg CLANG_VERSION=${{ matrix.version.clang }} \
+          --tag ${{ github.event.repository.name }}/${{ matrix.version.os }}:clang{{ matrix.version.clang }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# IDEs.
+.idea
+.vscode
+settings.json
+
+# OS.
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# ci
+# CI
+
 Images and workflows for use by CI pipelines.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,66 @@
+# ====================== BASE IMAGE ======================
+ARG UBUNTU_VERSION=jammy
+FROM ubuntu:${UBUNTU_VERSION} AS base
+
+# Associate the image with the repository.
+ARG GITHUB_REPO=XRPLF/ci
+LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPO}
+
+# Ensure any packages installed directly or indirectly via dpkg do not require
+# manual interaction.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt upgrade -y && \
+    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
+    apt install tzdata && \
+    dpkg-reconfigure --frontend noninteractive tzdata
+
+# Install tools that are shared by all stages.
+RUN apt install -y build-essential \
+                        ca-certificates \
+                        cmake \
+                        curl \
+                        git \
+                        gpg \
+                        libssl-dev \
+                        libprotobuf-dev \
+                        ninja-build \
+                        protobuf-compiler
+
+# Install Conan.
+RUN apt install -y pipx
+RUN PIPX_HOME=/opt/pipx \
+         PIPX_BIN_DIR=/usr/bin \
+         PIPX_MAN_DIR=/usr/share/man \
+         pipx install conan
+
+# Create the user to switch to, once all packages have been installed.
+ARG NONROOT_USER=ci
+RUN useradd -ms /bin/bash ${NONROOT_USER}
+
+# ====================== GCC IMAGE ======================
+FROM base AS gcc
+
+# Install GCC.
+ARG GCC_VERSION=12
+RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
+ENV CC=/usr/bin/gcc-${GCC_VERSION}
+ENV CXX=/usr/bin/gcc-${GCC_VERSION}
+RUN rm -rf /var/lib/apt/lists/*
+
+# Switch to the non-root user.
+USER ${NONROOT_USER}
+WORKDIR /home/${NONROOT_USER}
+
+# ===================== CLANG IMAGE =====================
+FROM base AS clang
+
+# Install Clang.
+ARG CLANG_VERSION=16
+RUN apt install -y clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
+ENV CC=clang-${CLANG_VERSION}
+ENV CXX=clang++-${CLANG_VERSION}
+RUN rm -rf /var/lib/apt/lists/*
+
+# Switch to the non-root user.
+USER ${NONROOT_USER}
+WORKDIR /home/${NONROOT_USER}

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -1,0 +1,80 @@
+## Ubuntu: A Docker image used to build and test rippled
+
+The code in this repository creates a locked-down Ubuntu image for building and
+testing rippled in the GitHub CI pipelines.
+
+### Logging into the Docker registry
+
+To be able to push to GitHub a personal access token is needed, see instructions
+[here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
+In summary, if you do not have a suitable personal access token, generate one
+[here](https://github.com/settings/tokens/new?scopes=write:packages).
+
+```shell
+DOCKER_REGISTRY=ghcr.io
+GITHUB_USER=<your-github-username>
+GITHUB_TOKEN=<your-github-personal-access-token>
+echo ${GITHUB_TOKEN} | \
+docker login ${DOCKER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
+```
+
+### Building and pushing the Docker image
+
+The same Dockerfile can be used to build an image for Ubuntu 22.04 and 24.04 by
+specifying the `UBUNTU_VERSION` build argument. There are additional arguments
+to specify as well, namely `CMAKE_VERSION` and `GCC_VERSION` for the GCC flavor
+and `CMAKE_VERSION` and `CLANG_VERSION` for the Clang flavor.
+
+Run the commands below from the current directory containing the Dockerfile.
+
+#### Building the Docker image for GCC.
+
+Ensure you've run the login command above to authenticate with the Docker
+registry.
+
+```shell
+UBUNTU_VERSION=noble
+GCC_VERSION=14
+DOCKER_IMAGE=xrplf/ci/${UBUNTU_VERSION}:gcc${GCC_VERSION}
+
+DOCKER_BUILDKIT=1 docker build . \
+  --target gcc \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+  --build-arg GCC_VERSION=${GCC_VERSION} \
+  --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
+  --platform linux/amd64
+
+docker push ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
+```
+
+#### Building the Docker image for Clang.
+
+Ensure you've run the login command above to authenticate with the Docker
+registry.
+
+```shell
+UBUNTU_VERSION=noble
+CLANG_VERSION=18
+DOCKER_IMAGE=xrplf/ci/${UBUNTU_VERSION}:clang${CLANG_VERSION}
+
+DOCKER_BUILDKIT=1 docker build . \
+  --target clang \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+  --build-arg CLANG_VERSION=${CLANG_VERSION} \
+  --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
+  --platform linux/amd64
+
+docker push ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
+```
+
+### List of Docker images built for CI
+
+As our code requires a minimum of GCC 12 and Clang 16, and Ubuntu only supports
+certain versions depending on the release, we have built the following images
+and pushed them to the GitHub Container Registry:
+* `ghcr.io/xrplf/ci/jammy:gcc12`
+* `ghcr.io/xrplf/ci/noble:gcc14`
+* `ghcr.io/xrplf/ci/noble:clang18`
+* `ghcr.io/xrplf/ci/noble:clang19`


### PR DESCRIPTION
This PR adds Docker images for Ubuntu 22.04 (jammy) and 24.04 (noble), with GCC or Clang if supported.