### PR TITLE
Add Debian Docker images

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -28,7 +28,7 @@ jobs:
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |
@@ -67,7 +67,7 @@ jobs:
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,6 +1,6 @@
 # Build Docker images for Debian with different versions of GCC and Clang and
 # push them to the GitHub Container Registry.
-# Note: Environment variables used in the workflow are defined in the repository
+# Note: Some environment variables used in the workflow are defined in the repo
 # settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Debian
 
@@ -9,6 +9,10 @@ on:
     paths:
       - .github/workflows/debian.yml
       - docker/debian/Dockerfile
+
+env:
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
 
 jobs:
   # Build the Docker image for Debian using different versions of GCC.
@@ -27,17 +31,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
@@ -67,13 +71,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,6 +1,8 @@
 name: Debian
 
-on: push
+on:
+  push:
+    paths: ['docker/debian/**']
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -45,6 +47,8 @@ jobs:
         version:
           - os: bookworm
             clang: 16
+          - os: bookworm
+            clang: 19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,69 @@
+name: Debian
+
+on: push
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+
+jobs:
+  # Build the Docker image for Debian using different versions of GCC.
+  gcc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - os: bookworm
+            gcc: 12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+      - name: Determine the Docker image name.
+        run: |
+          # Convert the repository name to lowercase as the organization name is
+          # uppercase, which is not permitted by the Docker registry.
+          DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+      - name: Build the Docker image
+        working-directory: docker/ubuntu
+        run: |
+          DOCKER_BUILDKIT=1 docker build . \
+          --target gcc \
+          --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
+          --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
+          --build-arg GCC_VERSION=${{ matrix.version.gcc }} \
+          --tag ${{ env.DOCKER_IMAGE }}
+      - name: Push the Docker image
+        run: docker push ${{ env.DOCKER_IMAGE }}
+
+  # Build the Docker image for Debian using different versions of Clang.
+  clang:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - os: bookworm
+            clang: 16
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+      - name: Determine the Docker image name.
+        run: |
+          # Convert the repository name to lowercase as the organization name is
+          # uppercase, which is not permitted by the Docker registry.
+          DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+      - name: Build the Docker image
+        working-directory: docker/ubuntu
+        run: |
+          DOCKER_BUILDKIT=1 docker build . \
+          --target clang \
+          --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
+          --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
+          --build-arg CLANG_VERSION=${{ matrix.version.clang }} \
+          --tag ${{ env.DOCKER_IMAGE }}
+      - name: Push the Docker image
+        run: docker push ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build the Docker image
         working-directory: docker/debian
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -2,8 +2,7 @@ name: Debian
 
 on:
   push:
-    #paths: ['docker/debian/Dockerfile']
-  #workflow_dispatch:
+    paths: ['docker/debian/Dockerfile']
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -49,7 +49,13 @@ jobs:
           - os: bookworm
             clang: 16
           - os: bookworm
+            clang: 17
+          - os: bookworm
+            clang: 18
+          - os: bookworm
             clang: 19
+          - os: bookworm
+            clang: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   DOCKER_REGISTRY: ghcr.io
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+  CONAN_VERSION: 2.17.0
 
 jobs:
   # Build the Docker image for Debian using different versions of GCC.
@@ -37,6 +40,7 @@ jobs:
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
           --build-arg GCC_VERSION=${{ matrix.version.gcc }} \
+          --build-arg CONAN_VERSION=${{ env.CONAN_VERSION }} \
           --tag ${{ env.DOCKER_IMAGE }}
       - name: Push the Docker image
         run: docker push ${{ env.DOCKER_IMAGE }}
@@ -71,11 +75,12 @@ jobs:
       - name: Build the Docker image
         working-directory: docker/debian
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target clang \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
           --build-arg CLANG_VERSION=${{ matrix.version.clang }} \
+          --build-arg CONAN_VERSION=${{ env.CONAN_VERSION }} \
           --tag ${{ env.DOCKER_IMAGE }}
       - name: Push the Docker image
         run: docker push ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -21,6 +21,10 @@ jobs:
         version:
           - os: bookworm
             gcc: 12
+          - os: bookworm
+            gcc: 13
+          - os: bookworm
+            gcc: 14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,3 +1,7 @@
+# Build Docker images for Debian with different versions of GCC and Clang and
+# push them to the GitHub Container Registry.
+# Note: Environment variables used in the workflow are defined in the repository
+# settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Debian
 
 on:
@@ -5,12 +9,6 @@ on:
     paths:
       - .github/workflows/debian.yml
       - docker/debian/Dockerfile
-
-env:
-  DOCKER_REGISTRY: ghcr.io
-  DOCKER_BUILDKIT: 1
-  BUILDKIT_PROGRESS: plain
-  CONAN_VERSION: 2.17.0
 
 jobs:
   # Build the Docker image for Debian using different versions of GCC.

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -3,6 +3,7 @@ name: Debian
 on:
   push:
     paths: ['docker/debian/Dockerfile']
+  workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -2,8 +2,8 @@ name: Debian
 
 on:
   push:
-    paths: ['docker/debian/Dockerfile']
-  workflow_dispatch:
+    #paths: ['docker/debian/Dockerfile']
+  #workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -2,7 +2,9 @@ name: Debian
 
 on:
   push:
-    paths: ['docker/debian/Dockerfile']
+    paths:
+      - .github/workflows/debian.yml
+      - docker/debian/Dockerfile
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -29,7 +29,7 @@ jobs:
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
           echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
-        working-directory: docker/ubuntu
+        working-directory: docker/debian
         run: |
           DOCKER_BUILDKIT=1 docker build . \
           --target gcc \
@@ -68,7 +68,7 @@ jobs:
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
           echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
-        working-directory: docker/ubuntu
+        working-directory: docker/debian
         run: |
           DOCKER_BUILDKIT=1 docker build . \
           --target clang \

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,7 +1,3 @@
-# Build Docker images for Debian with different versions of GCC and Clang and
-# push them to the GitHub Container Registry.
-# Note: Some environment variables used in the workflow are defined in the repo
-# settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Debian
 
 on:
@@ -11,8 +7,10 @@ on:
       - docker/debian/Dockerfile
 
 env:
+  DOCKER_REGISTRY: ghcr.io
   DOCKER_BUILDKIT: 1
   BUILDKIT_PROGRESS: plain
+  CONAN_VERSION: 2.17.0
 
 jobs:
   # Build the Docker image for Debian using different versions of GCC.
@@ -31,17 +29,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |
-          docker build . \
+          DOCKER_BUILDKIT=1 docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg DEBIAN_VERSION=${{ matrix.version.os }} \
@@ -71,13 +69,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/debian-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/debian
         run: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -2,7 +2,7 @@ name: Debian
 
 on:
   push:
-    paths: ['docker/debian/**']
+    paths: ['docker/debian/Dockerfile']
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,7 +1,3 @@
-# Build Docker images for Ubuntu with different versions of GCC and Clang and
-# push them to the GitHub Container Registry.
-# Note: Some environment variables used in the workflow are defined in the repo
-# settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Ubuntu
 
 on:
@@ -11,8 +7,10 @@ on:
       - docker/ubuntu/Dockerfile
 
 env:
+  DOCKER_REGISTRY: ghcr.io
   DOCKER_BUILDKIT: 1
   BUILDKIT_PROGRESS: plain
+  CONAN_VERSION: 2.17.0
 
 jobs:
   # Build the Docker image for Ubuntu using different versions of GCC. See
@@ -32,17 +30,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |
-          docker build . \
+          DOCKER_BUILDKIT=1 docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
@@ -71,13 +69,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,6 @@
 # Build Docker images for Ubuntu with different versions of GCC and Clang and
 # push them to the GitHub Container Registry.
-# Note: Environment variables used in the workflow are defined in the repository
+# Note: Some environment variables used in the workflow are defined in the repo
 # settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Ubuntu
 
@@ -9,6 +9,10 @@ on:
     paths:
       - .github/workflows/ubuntu.yml
       - docker/ubuntu/Dockerfile
+
+env:
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
 
 jobs:
   # Build the Docker image for Ubuntu using different versions of GCC. See
@@ -28,17 +32,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
@@ -67,13 +71,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${DOCKER_REGISTRY} -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.DOCKER_REGISTRY }} -u ${{ github.repository_owner }} --password-stdin
       - name: Determine the Docker image name.
         run: |
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${{ env.DOCKER_REGISTRY }}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:gcc${{ matrix.version.gcc }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |
@@ -69,7 +69,7 @@ jobs:
           # Convert the repository name to lowercase as the organization name is
           # uppercase, which is not permitted by the Docker registry.
           DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}
-          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE=${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/ubuntu-${{ matrix.version.os }}:clang${{ matrix.version.clang }}" >> $GITHUB_ENV
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,6 +3,7 @@ name: Ubuntu
 on:
   push:
     paths: ['docker/ubuntu/Dockerfile']
+    workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,6 @@ name: Ubuntu
 on:
   push:
     paths: ['docker/ubuntu/Dockerfile']
-  workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target gcc \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,3 +1,7 @@
+# Build Docker images for Ubuntu with different versions of GCC and Clang and
+# push them to the GitHub Container Registry.
+# Note: Environment variables used in the workflow are defined in the repository
+# settings at https://github.com/XRPLF/ci/settings/variables/actions.
 name: Ubuntu
 
 on:
@@ -6,14 +10,9 @@ on:
       - .github/workflows/ubuntu.yml
       - docker/ubuntu/Dockerfile
 
-env:
-  DOCKER_REGISTRY: ghcr.io
-  DOCKER_BUILDKIT: 1
-  BUILDKIT_PROGRESS: plain
-  CONAN_VERSION: 2.17.0
-
 jobs:
-  # Build the Docker image for Ubuntu using different versions of GCC.
+  # Build the Docker image for Ubuntu using different versions of GCC. See
+  # https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/gcc/.
   gcc:
     runs-on: ubuntu-latest
     strategy:
@@ -49,7 +48,8 @@ jobs:
       - name: Push the Docker image
         run: docker push ${{ env.DOCKER_IMAGE }}
 
-  # Build the Docker image for Ubuntu using different versions of Clang.
+  # Build the Docker image for Ubuntu using different versions of Clang. See
+  # https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/llvm/.
   clang:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,7 @@ name: Ubuntu
 
 on:
   push:
-    paths: ['docker/ubuntu/**']
+    paths: ['docker/ubuntu/Dockerfile']
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   DOCKER_REGISTRY: ghcr.io
+  DOCKER_BUILDKIT: 1
+  BUILDKIT_PROGRESS: plain
+  CONAN_VERSION: 2.17.0
 
 jobs:
   # Build the Docker image for Ubuntu using different versions of GCC.
@@ -41,6 +44,7 @@ jobs:
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
           --build-arg GCC_VERSION=${{ matrix.version.gcc }} \
+          --build-arg CONAN_VERSION=${{ env.CONAN_VERSION }} \
           --tag ${{ env.DOCKER_IMAGE }}
       - name: Push the Docker image
         run: docker push ${{ env.DOCKER_IMAGE }}
@@ -73,11 +77,12 @@ jobs:
       - name: Build the Docker image
         working-directory: docker/ubuntu
         run: |
-          DOCKER_BUILDKIT=1 docker build . \
+          docker build . \
           --target clang \
           --build-arg GITHUB_REPO=${GITHUB_REPOSITORY} \
           --build-arg UBUNTU_VERSION=${{ matrix.version.os }} \
           --build-arg CLANG_VERSION=${{ matrix.version.clang }} \
+          --build-arg CONAN_VERSION=${{ env.CONAN_VERSION }} \
           --tag ${{ env.DOCKER_IMAGE }}
       - name: Push the Docker image
         run: docker push ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,7 +2,9 @@ name: Ubuntu
 
 on:
   push:
-    paths: ['docker/ubuntu/Dockerfile']
+    paths:
+      - .github/workflows/ubuntu.yml
+      - docker/ubuntu/Dockerfile
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,7 +3,7 @@ name: Ubuntu
 on:
   push:
     paths: ['docker/ubuntu/Dockerfile']
-    workflow_dispatch:
+  workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,8 @@
 name: Ubuntu
 
-on: push
+on:
+  push:
+    paths: ['docker/ubuntu/**']
 
 env:
   DOCKER_REGISTRY: ghcr.io

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -32,7 +32,7 @@ RUN PIPX_HOME=/opt/pipx \
          PIPX_BIN_DIR=/usr/bin \
          PIPX_MAN_DIR=/usr/share/man \
          pipx install conan
-RUN apt remove -y pipx && apt autoremove -y
+RUN apt purge -y pipx
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -46,7 +46,9 @@ ARG GCC_VERSION=12
 RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
 ENV CC=/usr/bin/gcc-${GCC_VERSION}
 ENV CXX=/usr/bin/gcc-${GCC_VERSION}
-RUN rm -rf /var/lib/apt/lists/*
+
+# Clean up unnecessary files to reduce image size.
+RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}
@@ -55,12 +57,20 @@ WORKDIR /home/${NONROOT_USER}
 # ===================== CLANG IMAGE =====================
 FROM base AS clang
 
-# Install Clang.
+# Install Clang. Use the LLVM apt repository to access the latest versions.
 ARG CLANG_VERSION=16
-RUN apt install -y clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg && \
+    printf "%s\n%s\n" \
+      "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \
+      "deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \
+      | tee /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -t llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} -y --no-install-recommends clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
 ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
-RUN rm -rf /var/lib/apt/lists/*
+
+# Clean up unnecessary files to reduce image size.
+RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -30,22 +30,24 @@ RUN set -ex ;\
 # Install tools that are shared by all stages.
 RUN <<EOF
     pkgs=()
-    pkgs+=(build-essential)   # Required build tools.
-    pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-    pkgs+=(cmake)             # Required build tool.
-    pkgs+=(curl)              # Dependency for tools requiring downloading data.
-    pkgs+=(git)               # Required build tool.
-    pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
-    pkgs+=(jq)                # Pretty printing.
-    pkgs+=(ninja-build)       # Required build tool.
-    pkgs+=(python3-pip)       # Dependency to install Conan.
-    pkgs+=(python-is-python3) # Make python point to python3.
+    pkgs+=(build-essential) # Required build tools.
+    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)           # Required build tool.
+    pkgs+=(curl)            # Dependency for tools requiring downloading data.
+    pkgs+=(git)             # Required build tool.
+    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)              # Pretty printing.
+    pkgs+=(ninja-build)     # Required build tool.
+    pkgs+=(pipx)            # Package manager for Python applications.
     apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN pip install conan==${CONAN_VERSION} --break-system-packages
+RUN PIPX_HOME=/opt/pipx \
+    PIPX_BIN_DIR=/usr/bin \
+    PIPX_MAN_DIR=/usr/share/man \
+    pipx install conan==${CONAN_VERSION}
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -57,9 +57,12 @@ WORKDIR /home/${NONROOT_USER}
 # ===================== CLANG IMAGE =====================
 FROM base AS clang
 
-# Install Clang. Use the LLVM apt repository to access the latest versions.
+# Install Clang. Use the LLVM apt repository to access the latest versions. We
+# must repeat the DEBIAN_VERSION argument here, as it is not inherited from the
+# base image.
+ARG DEBIAN_VERSION
 ARG CLANG_VERSION=16
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg && \
+RUN curl --no-progress-meter https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg && \
     printf "%s\n%s\n" \
       "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \
       "deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -32,7 +32,7 @@ RUN PIPX_HOME=/opt/pipx \
          PIPX_BIN_DIR=/usr/bin \
          PIPX_MAN_DIR=/usr/share/man \
          pipx install conan
-RUN apt purge -y pipx
+RUN apt purge -y pipx && apt autoremove -y
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -64,8 +64,8 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc
       "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \
       "deb-src [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${DEBIAN_VERSION}/ llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} main" \
       | tee /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && \
-    apt-get install -t llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} -y --no-install-recommends clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
+    apt update && \
+    apt install -t llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} -y --no-install-recommends clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
 ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
 

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -30,24 +30,22 @@ RUN set -ex ;\
 # Install tools that are shared by all stages.
 RUN <<EOF
     pkgs=()
-    pkgs+=(build-essential) # Required build tools.
-    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-    pkgs+=(cmake)           # Required build tool.
-    pkgs+=(curl)            # Dependency for tools requiring downloading data.
-    pkgs+=(git)             # Required build tool.
-    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
-    pkgs+=(jq)              # Pretty printing.
-    pkgs+=(ninja-build)     # Required build tool.
-    pkgs+=(pipx)            # Package manager for Python applications.
+    pkgs+=(build-essential)   # Required build tools.
+    pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)             # Required build tool.
+    pkgs+=(curl)              # Dependency for tools requiring downloading data.
+    pkgs+=(git)               # Required build tool.
+    pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)                # Pretty printing.
+    pkgs+=(ninja-build)       # Required build tool.
+    pkgs+=(python3-pip)       # Dependency to install Conan.
+    pkgs+=(python-is-python3) # Make python point to python3.
     apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN PIPX_HOME=/opt/pipx \
-    PIPX_BIN_DIR=/usr/bin \
-    PIPX_MAN_DIR=/usr/share/man \
-    pipx install conan==${CONAN_VERSION}
+RUN pip install conan==${CONAN_VERSION} --break-system-packages
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,6 +1,9 @@
 # Define the source image from which we will copy GCC. This is needed because
 # the `COPY --from XXX` command used in a stage below does not allow `XXX` to
-# contain dynamic values supplied via an argument.
+# contain dynamic values supplied via an argument. We are using GCC image rather
+# than the official Debian package to access the latest versions, built by the
+# GCC team specifically for this Debian release. For build images using official
+# distribution packages, see Ubuntu.
 ARG DEBIAN_VERSION=bookworm
 ARG GCC_VERSION=12
 FROM gcc:${GCC_VERSION}-${DEBIAN_VERSION} AS gcc-src
@@ -34,11 +37,12 @@ RUN apt install -y build-essential \
                    protobuf-compiler
 
 # Install Conan.
+ARG CONAN_VERSION=2.17.0
 RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/bin \
     PIPX_MAN_DIR=/usr/share/man \
-    pipx install conan
+    pipx install conan==${CONAN_VERSION}
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -51,12 +55,13 @@ FROM base AS gcc
 # existence, and create the necessary symlinks.
 COPY --from=gcc-src /usr/local/ /usr/local/
 COPY --from=gcc-src /etc/ld.so.conf.d/*.conf /etc/ld.so.conf.d/
-RUN set -ex ;\
-    ldconfig -v ;\
-    dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc ;\
-    dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ ;\
-    dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran ;\
-    update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999 ;\
+RUN <<EOF
+    set -ex
+    ldconfig -v
+    dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc
+    dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++
+    dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran
+    update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999
     update-alternatives --install \
       /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
       --slave /usr/bin/g++ g++ /usr/local/bin/g++ \
@@ -66,12 +71,13 @@ RUN set -ex ;\
       --slave /usr/bin/gcov gcov /usr/local/bin/gcov \
       --slave /usr/bin/gcov-tool gcov-tool /usr/local/bin/gcov-tool \
       --slave /usr/bin/gcov-dump gcov-dump /usr/local/bin/gcov-dump \
-      --slave /usr/bin/lto-dump lto-dump /usr/local/bin/lto-dump ;\
-    update-alternatives --auto cc ;\
+      --slave /usr/bin/lto-dump lto-dump /usr/local/bin/lto-dump
+    update-alternatives --auto cc
     update-alternatives --auto gcc
+EOF
 
 # Clean up unnecessary files to reduce image size.
-RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
+RUN rm -rf /var/lib/apt/lists/* && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}
@@ -99,7 +105,7 @@ ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
 
 # Clean up unnecessary files to reduce image size.
-RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
+RUN rm -rf /var/lib/apt/lists/* && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -21,7 +21,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y
 RUN set -ex ;\
     ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime ;\
-    apt install tzdata ;\
+    apt install -y tzdata ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -11,6 +11,9 @@ FROM gcc:${GCC_VERSION}-${DEBIAN_VERSION} AS gcc-src
 # ====================== BASE IMAGE ======================
 FROM debian:${DEBIAN_VERSION} AS base
 
+# Use Bash as the default shell for RUN commands.
+SHELL ["/bin/bash", "-c"]
+
 # Associate the image with the repository.
 ARG GITHUB_REPO=XRPLF/ci
 LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPO}
@@ -26,21 +29,21 @@ RUN set -ex ;\
 
 # Install tools that are shared by all stages.
 RUN <<EOF
-  pkgs=()
-  pkgs+=(build-essential) # Required build tools.
-  pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-  pkgs+=(cmake)           # Required build tool.
-  pkgs+=(curl)            # Dependency for tools requiring downloading data.
-  pkgs+=(git)             # Required build tool.
-  pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
-  pkgs+=(jq)              # Pretty printing.
-  pkgs+=(ninja-build)     # Required build tool.
-  apt install -y "${pkgs[@]}"
+    pkgs=()
+    pkgs+=(build-essential) # Required build tools.
+    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)           # Required build tool.
+    pkgs+=(curl)            # Dependency for tools requiring downloading data.
+    pkgs+=(git)             # Required build tool.
+    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)              # Pretty printing.
+    pkgs+=(ninja-build)     # Required build tool.
+    pkgs+=(pipx)            # Package manager for Python applications.
+    apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/bin \
     PIPX_MAN_DIR=/usr/share/man \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,6 +1,6 @@
 # ====================== BASE IMAGE ======================
-ARG UBUNTU_VERSION=jammy
-FROM ubuntu:${UBUNTU_VERSION} AS base
+ARG DEBIAN_VERSION=bookworm
+FROM debian:${DEBIAN_VERSION} AS base
 
 # Associate the image with the repository.
 ARG GITHUB_REPO=XRPLF/ci

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,5 +1,11 @@
-# ====================== BASE IMAGE ======================
+# Define the source image from which we will copy GCC. This is needed because
+# the `COPY --from XXX` command used in a stage below does not allow `XXX` to
+# contain dynamic values supplied via an argument.
 ARG DEBIAN_VERSION=bookworm
+ARG GCC_VERSION=12
+FROM gcc:${GCC_VERSION}-${DEBIAN_VERSION} AS gcc-src
+
+# ====================== BASE IMAGE ======================
 FROM debian:${DEBIAN_VERSION} AS base
 
 # Associate the image with the repository.
@@ -9,30 +15,30 @@ LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPO}
 # Ensure any packages installed directly or indirectly via dpkg do not require
 # manual interaction.
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt upgrade -y && \
-    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
-    apt install tzdata && \
+RUN apt update && apt upgrade -y
+RUN set -ex ;\
+    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime ;\
+    apt install tzdata ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.
 RUN apt install -y build-essential \
-                        ca-certificates \
-                        cmake \
-                        curl \
-                        git \
-                        gpg \
-                        libssl-dev \
-                        libprotobuf-dev \
-                        ninja-build \
-                        protobuf-compiler
+                   ca-certificates \
+                   cmake \
+                   curl \
+                   git \
+                   gpg \
+                   libssl-dev \
+                   libprotobuf-dev \
+                   ninja-build \
+                   protobuf-compiler
 
 # Install Conan.
 RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
-         PIPX_BIN_DIR=/usr/bin \
-         PIPX_MAN_DIR=/usr/share/man \
-         pipx install conan
-RUN apt purge -y pipx && apt autoremove -y
+    PIPX_BIN_DIR=/usr/bin \
+    PIPX_MAN_DIR=/usr/share/man \
+    pipx install conan
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -41,11 +47,28 @@ RUN useradd -ms /bin/bash ${NONROOT_USER}
 # ====================== GCC IMAGE ======================
 FROM base AS gcc
 
-# Install GCC.
-ARG GCC_VERSION=12
-RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
-ENV CC=/usr/bin/gcc-${GCC_VERSION}
-ENV CXX=/usr/bin/gcc-${GCC_VERSION}
+# Copy GCC from the source image, make the package manager aware of its
+# existence, and create the necessary symlinks.
+COPY --from=gcc-src /usr/local/ /usr/local/
+COPY --from=gcc-src /etc/ld.so.conf.d/*.conf /etc/ld.so.conf.d/
+RUN set -ex ;\
+    ldconfig -v ;\
+    dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc ;\
+    dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ ;\
+    dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran ;\
+    update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999 ;\
+    update-alternatives --install \
+      /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
+      --slave /usr/bin/g++ g++ /usr/local/bin/g++ \
+      --slave /usr/bin/gcc-ar gcc-ar /usr/local/bin/gcc-ar \
+      --slave /usr/bin/gcc-nm gcc-nm /usr/local/bin/gcc-nm \
+      --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/local/bin/gcc-ranlib \
+      --slave /usr/bin/gcov gcov /usr/local/bin/gcov \
+      --slave /usr/bin/gcov-tool gcov-tool /usr/local/bin/gcov-tool \
+      --slave /usr/bin/gcov-dump gcov-dump /usr/local/bin/gcov-dump \
+      --slave /usr/bin/lto-dump lto-dump /usr/local/bin/lto-dump ;\
+    update-alternatives --auto cc ;\
+    update-alternatives --auto gcc
 
 # Clean up unnecessary files to reduce image size.
 RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
@@ -53,6 +76,9 @@ RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 # Switch to the non-root user.
 USER ${NONROOT_USER}
 WORKDIR /home/${NONROOT_USER}
+
+# Create a default Conan profile.
+RUN conan profile detect
 
 # ===================== CLANG IMAGE =====================
 FROM base AS clang
@@ -78,3 +104,6 @@ RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 # Switch to the non-root user.
 USER ${NONROOT_USER}
 WORKDIR /home/${NONROOT_USER}
+
+# Create a default Conan profile.
+RUN conan profile detect

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -25,16 +25,18 @@ RUN set -ex ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.
-RUN apt install -y build-essential \
-                   ca-certificates \
-                   cmake \
-                   curl \
-                   git \
-                   gpg \
-                   libssl-dev \
-                   libprotobuf-dev \
-                   ninja-build \
-                   protobuf-compiler
+RUN <<EOF
+  pkgs=()
+  pkgs+=(build-essential) # Required build tools.
+  pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+  pkgs+=(cmake)           # Required build tool.
+  pkgs+=(curl)            # Dependency for tools requiring downloading data.
+  pkgs+=(git)             # Required build tool.
+  pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+  pkgs+=(jq)              # Pretty printing.
+  pkgs+=(ninja-build)     # Required build tool.
+  apt install -y "${pkgs[@]}"
+EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -39,6 +39,7 @@ registry.
 ```shell
 DEBIAN_VERSION=bookworm
 GCC_VERSION=12
+CONAN_VERSION=2.17.0
 DOCKER_IMAGE=xrplf/ci/debian-${DEBIAN_VERSION}:gcc${GCC_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
@@ -46,6 +47,7 @@ DOCKER_BUILDKIT=1 docker build . \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg DEBIAN_VERSION=${DEBIAN_VERSION} \
   --build-arg GCC_VERSION=${GCC_VERSION} \
+  --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64
 
@@ -60,6 +62,7 @@ registry.
 ```shell
 DEBIAN_VERSION=bookworm
 CLANG_VERSION=17
+CONAN_VERSION=2.17.0
 DOCKER_IMAGE=xrplf/ci/debian-${DEBIAN_VERSION}:clang${CLANG_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
@@ -67,6 +70,7 @@ DOCKER_BUILDKIT=1 docker build . \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg DEBIAN_VERSION=${DEBIAN_VERSION} \
   --build-arg CLANG_VERSION=${CLANG_VERSION} \
+  --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64
 

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -1,6 +1,6 @@
-## Ubuntu: A Docker image used to build and test rippled
+## Debian: A Docker image used to build and test rippled
 
-The code in this repository creates a locked-down Ubuntu image for building and
+The code in this repository creates a locked-down Debuan image for building and
 testing rippled in the GitHub CI pipelines.
 
 Although the images will be built by a CI pipeline in this repository, if
@@ -24,8 +24,8 @@ docker login ${DOCKER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
 
 ### Building and pushing the Docker image
 
-The same Dockerfile can be used to build an image for Ubuntu 22.04 and 24.04 by
-specifying the `UBUNTU_VERSION` build argument. There are additional arguments
+The same Dockerfile can be used to build an image for Debian Bookworm by
+specifying the `DEBIAN_VERSION` build argument. There are additional arguments
 to specify as well, namely `GCC_VERSION` for the GCC flavor and `CLANG_VERSION`
 for the Clang flavor.
 
@@ -37,14 +37,14 @@ Ensure you've run the login command above to authenticate with the Docker
 registry.
 
 ```shell
-UBUNTU_VERSION=noble
-GCC_VERSION=14
-DOCKER_IMAGE=xrplf/ci/${UBUNTU_VERSION}:gcc${GCC_VERSION}
+DEBIAN_VERSION=bookworm
+GCC_VERSION=12
+DOCKER_IMAGE=xrplf/ci/${DEBIAN_VERSION}:gcc${GCC_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
   --target gcc \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+  --build-arg DEBIAN_VERSION=${DEBIAN_VERSION} \
   --build-arg GCC_VERSION=${GCC_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64
@@ -58,14 +58,14 @@ Ensure you've run the login command above to authenticate with the Docker
 registry.
 
 ```shell
-UBUNTU_VERSION=noble
-CLANG_VERSION=18
-DOCKER_IMAGE=xrplf/ci/${UBUNTU_VERSION}:clang${CLANG_VERSION}
+DEBIAN_VERSION=bookworm
+CLANG_VERSION=16
+DOCKER_IMAGE=xrplf/ci/${DEBIAN_VERSION}:clang${CLANG_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
   --target clang \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+  --build-arg DEBIAN_VERSION=${DEBIAN_VERSION} \
   --build-arg CLANG_VERSION=${CLANG_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -59,7 +59,7 @@ registry.
 
 ```shell
 DEBIAN_VERSION=bookworm
-CLANG_VERSION=16
+CLANG_VERSION=17
 DOCKER_IMAGE=xrplf/ci/debian-${DEBIAN_VERSION}:clang${CLANG_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
@@ -97,8 +97,9 @@ conan install . --build missing --settings build_type=${BUILD_TYPE} \
 cd build
 cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \
       -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-# Build rippled.
-cmake --build . -j $(nproc)
-# Run the tests.
-./rippled --unittest --unittest-jobs $(nproc)
+# Build and test rippled. Setting the parallelism too high, e.g. to $(nproc),
+# can result in an error like "gmake[2]: ...... Killed".
+PARALLELISM=4
+cmake --build . -j ${PARALLELISM}
+./rippled --unittest --unittest-jobs ${PARALLELISM}
 ```

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -24,10 +24,10 @@ docker login ${DOCKER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
 
 ### Building and pushing the Docker image
 
-The same Dockerfile can be used to build an image for Debian Bookworm by
-specifying the `DEBIAN_VERSION` build argument. There are additional arguments
-to specify as well, namely `GCC_VERSION` for the GCC flavor and `CLANG_VERSION`
-for the Clang flavor.
+The same Dockerfile can be used to build an image for Debian Bookworm or future
+versions by specifying the `DEBIAN_VERSION` build argument. There are additional
+arguments to specify as well, namely `GCC_VERSION` for the GCC flavor and
+`CLANG_VERSION` for the Clang flavor.
 
 Run the commands below from the current directory containing the Dockerfile.
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -28,11 +28,12 @@ RUN apt install -y build-essential \
                    protobuf-compiler
 
 # Install Conan.
+ARG CONAN_VERSION=2.17.0
 RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/bin \
     PIPX_MAN_DIR=/usr/share/man \
-    pipx install conan
+    pipx install conan==${CONAN_VERSION}
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -48,7 +49,7 @@ ENV CC=/usr/bin/gcc-${GCC_VERSION}
 ENV CXX=/usr/bin/gcc-${GCC_VERSION}
 
 # Clean up unnecessary files to reduce image size.
-RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
+RUN rm -rf /var/lib/apt/lists/* && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}
@@ -64,7 +65,7 @@ ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
 
 # Clean up unnecessary files to reduce image size.
-RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
+RUN rm -rf /var/lib/apt/lists/* && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -32,7 +32,7 @@ RUN PIPX_HOME=/opt/pipx \
          PIPX_BIN_DIR=/usr/bin \
          PIPX_MAN_DIR=/usr/share/man \
          pipx install conan
-RUN apt remove -y pipx && apt autoremove -y
+RUN apt purge -y pipx
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci
@@ -46,7 +46,9 @@ ARG GCC_VERSION=12
 RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
 ENV CC=/usr/bin/gcc-${GCC_VERSION}
 ENV CXX=/usr/bin/gcc-${GCC_VERSION}
-RUN rm -rf /var/lib/apt/lists/*
+
+# Clean up unnecessary files to reduce image size.
+RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}
@@ -60,7 +62,9 @@ ARG CLANG_VERSION=16
 RUN apt install -y clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
 ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
-RUN rm -rf /var/lib/apt/lists/*
+
+# Clean up unnecessary files to reduce image size.
+RUN rm -rf /var/lib/apt/lists/* && apt autoremove -y && apt clean
 
 # Switch to the non-root user.
 USER ${NONROOT_USER}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -2,6 +2,9 @@
 ARG UBUNTU_VERSION=jammy
 FROM ubuntu:${UBUNTU_VERSION} AS base
 
+# Use Bash as the default shell for RUN commands.
+SHELL ["/bin/bash", "-c"]
+
 # Associate the image with the repository.
 ARG GITHUB_REPO=XRPLF/ci
 LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPO}
@@ -17,21 +20,21 @@ RUN set -ex ;\
 
 # Install tools that are shared by all stages.
 RUN <<EOF
-  pkgs=()
-  pkgs+=(build-essential) # Required build tools.
-  pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-  pkgs+=(cmake)           # Required build tool.
-  pkgs+=(curl)            # Dependency for tools requiring downloading data.
-  pkgs+=(git)             # Required build tool.
-  pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
-  pkgs+=(jq)              # Pretty printing.
-  pkgs+=(ninja-build)     # Required build tool.
-  apt install -y "${pkgs[@]}"
+    pkgs=()
+    pkgs+=(build-essential) # Required build tools.
+    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)           # Required build tool.
+    pkgs+=(curl)            # Dependency for tools requiring downloading data.
+    pkgs+=(git)             # Required build tool.
+    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)              # Pretty printing.
+    pkgs+=(ninja-build)     # Required build tool.
+    pkgs+=(pipx)            # Package manager for Python applications.
+    apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/bin \
     PIPX_MAN_DIR=/usr/share/man \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -21,22 +21,24 @@ RUN set -ex ;\
 # Install tools that are shared by all stages.
 RUN <<EOF
     pkgs=()
-    pkgs+=(build-essential)   # Required build tools.
-    pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-    pkgs+=(cmake)             # Required build tool.
-    pkgs+=(curl)              # Dependency for tools requiring downloading data.
-    pkgs+=(git)               # Required build tool.
-    pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
-    pkgs+=(jq)                # Pretty printing.
-    pkgs+=(ninja-build)       # Required build tool.
-    pkgs+=(python3-pip)       # Dependency to install Conan.
-    pkgs+=(python-is-python3) # Make python point to python3.
+    pkgs+=(build-essential) # Required build tools.
+    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)           # Required build tool.
+    pkgs+=(curl)            # Dependency for tools requiring downloading data.
+    pkgs+=(git)             # Required build tool.
+    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)              # Pretty printing.
+    pkgs+=(ninja-build)     # Required build tool.
+    pkgs+=(pipx)            # Package manager for Python applications.
     apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN pip install conan==${CONAN_VERSION} --break-system-packages
+RUN PIPX_HOME=/opt/pipx \
+    PIPX_BIN_DIR=/usr/bin \
+    PIPX_MAN_DIR=/usr/share/man \
+    pipx install conan==${CONAN_VERSION}
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -16,16 +16,18 @@ RUN set -ex ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.
-RUN apt install -y build-essential \
-                   ca-certificates \
-                   cmake \
-                   curl \
-                   git \
-                   gpg \
-                   libssl-dev \
-                   libprotobuf-dev \
-                   ninja-build \
-                   protobuf-compiler
+RUN <<EOF
+  pkgs=()
+  pkgs+=(build-essential) # Required build tools.
+  pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+  pkgs+=(cmake)           # Required build tool.
+  pkgs+=(curl)            # Dependency for tools requiring downloading data.
+  pkgs+=(git)             # Required build tool.
+  pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
+  pkgs+=(jq)              # Pretty printing.
+  pkgs+=(ninja-build)     # Required build tool.
+  apt install -y "${pkgs[@]}"
+EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -32,7 +32,7 @@ RUN PIPX_HOME=/opt/pipx \
          PIPX_BIN_DIR=/usr/bin \
          PIPX_MAN_DIR=/usr/share/man \
          pipx install conan
-RUN apt purge -y pipx
+RUN apt purge -y pipx && apt autoremove -y
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -12,7 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y
 RUN set -ex ;\
     ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime ;\
-    apt install tzdata ;\
+    apt install -y tzdata ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -9,30 +9,30 @@ LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPO}
 # Ensure any packages installed directly or indirectly via dpkg do not require
 # manual interaction.
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt upgrade -y && \
-    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
-    apt install tzdata && \
+RUN apt update && apt upgrade -y
+RUN set -ex ;\
+    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime ;\
+    apt install tzdata ;\
     dpkg-reconfigure --frontend noninteractive tzdata
 
 # Install tools that are shared by all stages.
 RUN apt install -y build-essential \
-                        ca-certificates \
-                        cmake \
-                        curl \
-                        git \
-                        gpg \
-                        libssl-dev \
-                        libprotobuf-dev \
-                        ninja-build \
-                        protobuf-compiler
+                   ca-certificates \
+                   cmake \
+                   curl \
+                   git \
+                   gpg \
+                   libssl-dev \
+                   libprotobuf-dev \
+                   ninja-build \
+                   protobuf-compiler
 
 # Install Conan.
 RUN apt install -y pipx
 RUN PIPX_HOME=/opt/pipx \
-         PIPX_BIN_DIR=/usr/bin \
-         PIPX_MAN_DIR=/usr/share/man \
-         pipx install conan
-RUN apt purge -y pipx && apt autoremove -y
+    PIPX_BIN_DIR=/usr/bin \
+    PIPX_MAN_DIR=/usr/share/man \
+    pipx install conan
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -55,6 +55,9 @@ RUN rm -rf /var/lib/apt/lists/* && apt clean
 USER ${NONROOT_USER}
 WORKDIR /home/${NONROOT_USER}
 
+# Create a default Conan profile.
+RUN conan profile detect
+
 # ===================== CLANG IMAGE =====================
 FROM base AS clang
 
@@ -70,3 +73,6 @@ RUN rm -rf /var/lib/apt/lists/* && apt clean
 # Switch to the non-root user.
 USER ${NONROOT_USER}
 WORKDIR /home/${NONROOT_USER}
+
+# Create a default Conan profile.
+RUN conan profile detect

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -21,24 +21,22 @@ RUN set -ex ;\
 # Install tools that are shared by all stages.
 RUN <<EOF
     pkgs=()
-    pkgs+=(build-essential) # Required build tools.
-    pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-    pkgs+=(cmake)           # Required build tool.
-    pkgs+=(curl)            # Dependency for tools requiring downloading data.
-    pkgs+=(git)             # Required build tool.
-    pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
-    pkgs+=(jq)              # Pretty printing.
-    pkgs+=(ninja-build)     # Required build tool.
-    pkgs+=(pipx)            # Package manager for Python applications.
+    pkgs+=(build-essential)   # Required build tools.
+    pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+    pkgs+=(cmake)             # Required build tool.
+    pkgs+=(curl)              # Dependency for tools requiring downloading data.
+    pkgs+=(git)               # Required build tool.
+    pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
+    pkgs+=(jq)                # Pretty printing.
+    pkgs+=(ninja-build)       # Required build tool.
+    pkgs+=(python3-pip)       # Dependency to install Conan.
+    pkgs+=(python-is-python3) # Make python point to python3.
     apt install -y "${pkgs[@]}"
 EOF
 
 # Install Conan.
 ARG CONAN_VERSION=2.17.0
-RUN PIPX_HOME=/opt/pipx \
-    PIPX_BIN_DIR=/usr/bin \
-    PIPX_MAN_DIR=/usr/share/man \
-    pipx install conan==${CONAN_VERSION}
+RUN pip install conan==${CONAN_VERSION} --break-system-packages
 
 # Create the user to switch to, once all packages have been installed.
 ARG NONROOT_USER=ci

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -24,10 +24,10 @@ docker login ${DOCKER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
 
 ### Building and pushing the Docker image
 
-The same Dockerfile can be used to build an image for Ubuntu 22.04 and 24.04 by
-specifying the `UBUNTU_VERSION` build argument. There are additional arguments
-to specify as well, namely `GCC_VERSION` for the GCC flavor and `CLANG_VERSION`
-for the Clang flavor.
+The same Dockerfile can be used to build an image for Ubuntu 22.04 and 24.04 or
+future versions by specifying the `UBUNTU_VERSION` build argument. There are
+additional arguments to specify as well, namely `GCC_VERSION` for the GCC flavor
+and `CLANG_VERSION` for the Clang flavor.
 
 Run the commands below from the current directory containing the Dockerfile.
 

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -39,6 +39,7 @@ registry.
 ```shell
 UBUNTU_VERSION=noble
 GCC_VERSION=14
+CONAN_VERSION=2.17.0
 DOCKER_IMAGE=xrplf/ci/ubuntu-${UBUNTU_VERSION}:gcc${GCC_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
@@ -46,6 +47,7 @@ DOCKER_BUILDKIT=1 docker build . \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --build-arg GCC_VERSION=${GCC_VERSION} \
+  --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64
 
@@ -60,6 +62,7 @@ registry.
 ```shell
 UBUNTU_VERSION=noble
 CLANG_VERSION=18
+CONAN_VERSION=2.17.0
 DOCKER_IMAGE=xrplf/ci/ubuntu-${UBUNTU_VERSION}:clang${CLANG_VERSION}
 
 DOCKER_BUILDKIT=1 docker build . \
@@ -67,6 +70,7 @@ DOCKER_BUILDKIT=1 docker build . \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --build-arg CLANG_VERSION=${CLANG_VERSION} \
+  --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --tag ${DOCKER_REGISTRY}/${DOCKER_IMAGE} \
   --platform linux/amd64
 


### PR DESCRIPTION
This PR adds Docker images for Debian Bookworm with supported GCC or Clang compilers.

Small improvements are made to the Ubuntu image as well for consistency.