### PR TITLE
Fix silent test failure

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -143,7 +143,8 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF
 
@@ -222,6 +223,7 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -110,7 +110,8 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF
 
@@ -183,6 +184,7 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -123,7 +123,8 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF
 
@@ -197,6 +198,7 @@ RUN conan profile show
 # Test the image by compiling a simple C++ program.
 RUN --mount=type=bind,source=test,target=/test,readonly <<EOF
 cp -r /test test
-cd test && ./run.sh && cd ..
+cd test && ./run.sh
+cd ..
 rm -rf test
 EOF


### PR DESCRIPTION
This change will cause the `docker build` to fail, if the test program fails for whatever reason.