### PR TITLE
Apply workaround for 12.3 bug if needed

### DIFF
--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -104,6 +104,25 @@ cat >>${CONAN_HOME}/profiles/default <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
+
+# Apply workaround for gcc 12.1 bug, if needed (fixed in gcc 12.4)
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+RUN <<EOF
+mkdir test && cd test
+cat >main.cpp <<EOT
+#include <string>
+std::string f() { return "_" + std::string(" "); }
+EOT
+${CXX} -std=c++20 -Wall -Werror -O3 -c main.cpp || touch fail
+if [[ -f fail ]]; then
+  cat >>~/.conan2/profiles/default <<EOT
+tools.build:cxxflags=['-Wno-restrict']
+EOT
+fi
+cd .. && rm -rf test
+EOF
+
+
 # Print the Conan profile to verify the configuration.
 RUN conan profile show
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -117,6 +117,24 @@ cat >>~/.conan2/profiles/default <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
+
+# Apply workaround for gcc 12.1 bug, if needed (fixed in gcc 12.4)
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
+RUN <<EOF
+mkdir test && cd test
+cat >main.cpp <<EOT
+#include <string>
+std::string f() { return "_" + std::string(" "); }
+EOT
+${CXX} -std=c++20 -Wall -Werror -O3 -c main.cpp || touch fail
+if [[ -f fail ]]; then
+  cat >>~/.conan2/profiles/default <<EOT
+tools.build:cxxflags=['-Wno-restrict']
+EOT
+fi
+cd .. && rm -rf test
+EOF
+
 # Print the Conan profile to verify the configuration.
 RUN conan profile show
 


### PR DESCRIPTION
Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651 

Needed because (as of today) Ubuntu ships gcc 12.3 which is affected by this bug. Unsure about RHEL but they are veeery conservative with new releases, so it there's gcc-12 in RHEL, it is likely to be affected as well. 

Not needed in `debian` image because `gcc` in this image is based on https://hub.docker.com/_/gcc which closely follows GCC releases and has the fix.
