### PR TITLE
Set CONAN_HOME in every image with Conan installed

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -123,6 +123,9 @@ USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
 
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
+
 # Create a default Conan profile.
 RUN <<EOF
 conan profile detect
@@ -193,6 +196,9 @@ EOF
 USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
+
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
 RUN <<EOF

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -86,9 +86,8 @@ USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
 
-# Fix the Conan user home directory as it otherwise will point to the
-# /opt/app-root/src/.conan2 directory.
-ENV CONAN_HOME=/home/${NONROOT_USER}/.conan2
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
 RUN <<EOF
@@ -170,9 +169,8 @@ USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
 
-# Fix the Conan user home directory as it otherwise will point to the
-# /opt/app-root/src/.conan2 directory.
-ENV CONAN_HOME=/home/${NONROOT_USER}/.conan2
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
 RUN <<EOF

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -103,6 +103,9 @@ USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
 
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
+
 # Create a default Conan profile.
 RUN <<EOF
 conan profile detect
@@ -186,6 +189,9 @@ EOF
 USER ${NONROOT_USER}
 ENV HOME=/home/${NONROOT_USER}
 WORKDIR ${HOME}
+
+# Set Conan home directory, so the users of this image can find default profile
+ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
 RUN <<EOF


### PR DESCRIPTION
Turns out, github workflows overwrite `HOME` (who would have expected), so Conan 2 still cannot find the profiles we build inside the image. Set `CONAN_HOME` explicitly to fix this.