### PR TITLE
Add Jinja2

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -47,6 +47,7 @@ pkgs+=(jq)              # Pretty printing.
 pkgs+=(libc6-dev)       # Required build tool.
 pkgs+=(ninja-build)     # Required build tool.
 pkgs+=(pipx)            # Package manager for Python applications.
+pkgs+=(python3-jinja2)  # Required build tool.
 pkgs+=(wget)            # Required build tool.
 apt-get update
 apt-get install -y --no-install-recommends "${pkgs[@]}"

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -22,6 +22,7 @@ pkgs+=(jq)               # Pretty printing.
 pkgs+=(libstdc++-static) # Required to statically link libraries into rippled.
 pkgs+=(ninja-build)      # Required build tool.
 pkgs+=(perl-FindBin)     # Required to compile OpenSSL.
+pkgs+=(python3-jinja2)   # Required build tool.
 pkgs+=(python3-pip)      # Package manager for Python applications.
 pkgs+=(rpm-build)        # Required packaging tool.
 pkgs+=(rpmdevtools)      # Required packaging tool.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -36,6 +36,7 @@ pkgs+=(jq)              # Pretty printing.
 pkgs+=(libc6-dev)       # Required build tool.
 pkgs+=(ninja-build)     # Required build tool.
 pkgs+=(pipx)            # Package manager for Python applications.
+pkgs+=(python3-jinja2)  # Required build tool.
 pkgs+=(wget)            # Required build tool.
 apt-get update
 apt-get install -y --no-install-recommends "${pkgs[@]}"


### PR DESCRIPTION
To upgrade `protobuf` and `grpc` in rippled, Jinja2 is required.