### PR TITLE
Move options to global.conf

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -138,8 +138,7 @@ EOF
 RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
-cat >>~/.conan2/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -217,12 +216,11 @@ RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/d
 RUN <<EOF
 CXX_VER=$(${CXX} -dumpversion)
 CXX_VER=${CXX_VER%%.*}
-cat >>~/.conan2/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 if [[ ${CXX_VER} -ge 19 ]]; then
-    cat >>~/.conan2/profiles/default <<EOT
+    cat >> $(conan config home)/global.conf <<EOT
 tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
 EOT
 fi

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -135,7 +135,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
@@ -208,7 +208,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags. To ensure compatibility with a range of
 # Clang compilers, we must also add extra flags that apply to certain versions
 # of Clang.

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -101,8 +101,7 @@ EOF
 RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ${CONAN_HOME}/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
-cat >>${CONAN_HOME}/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -117,7 +116,7 @@ std::string f() { return "_" + std::string(" "); }
 EOT
 ${CXX} -std=c++20 -Wall -Werror -O3 -c main.cpp || touch fail
 if [[ -f fail ]]; then
-  cat >>~/.conan2/profiles/default <<EOT
+  cat >> $(conan config home)/global.conf <<EOT
 tools.build:cxxflags=['-Wno-restrict']
 EOT
 fi
@@ -189,12 +188,11 @@ RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ${CONAN_HOME}/profil
 RUN <<EOF
 CXX_VER=$(${CXX} -dumpversion)
 CXX_VER=${CXX_VER%%.*}
-cat >>${CONAN_HOME}/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 if [[ ${CXX_VER} -ge 19 ]]; then
-    cat >>${CONAN_HOME}/profiles/default <<EOT
+    cat >> $(conan config home)/global.conf <<EOT
 tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
 EOT
 fi

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -98,7 +98,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ${CONAN_HOME}/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
@@ -180,7 +180,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ${CONAN_HOME}/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags. To ensure compatibility with a range of
 # Clang compilers, we must also add extra flags that apply to certain versions
 # of Clang.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -115,7 +115,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
@@ -201,7 +201,7 @@ rm -rf /tmp/*
 EOF
 
 # Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
+RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
 # Explicitly set the compiler flags. To ensure compatibility with a range of
 # Clang compilers, we must also add extra flags that apply to certain versions
 # of Clang.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -118,8 +118,7 @@ EOF
 RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/default
 # Explicitly set the compiler flags.
 RUN <<EOF
-cat >>~/.conan2/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -134,7 +133,7 @@ std::string f() { return "_" + std::string(" "); }
 EOT
 ${CXX} -std=c++20 -Wall -Werror -O3 -c main.cpp || touch fail
 if [[ -f fail ]]; then
-  cat >>~/.conan2/profiles/default <<EOT
+  cat >> $(conan config home)/global.conf <<EOT
 tools.build:cxxflags=['-Wno-restrict']
 EOT
 fi
@@ -210,12 +209,11 @@ RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' ~/.conan2/profiles/d
 RUN <<EOF
 CXX_VER=$(${CXX} -dumpversion)
 CXX_VER=${CXX_VER%%.*}
-cat >>~/.conan2/profiles/default <<EOT
-[conf]
+cat >> $(conan config home)/global.conf <<EOT
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 if [[ ${CXX_VER} -ge 19 ]]; then
-    cat >>~/.conan2/profiles/default <<EOT
+    cat >> $(conan config home)/global.conf <<EOT
 tools.build:cxxflags=['-Wno-missing-template-arg-list-after-template-kw']
 EOT
 fi


### PR DESCRIPTION
We are currently storing the minimum required compiler options in `profiles/default` . This change will move them to `global.conf`, making it easier to consume the generated image from CI workflows. 