### PR TITLE
Add `debhelper` to base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ of environments and using different C++ compilers.
 [Debian instructions](docker/debian/README.md)
 [RHEL instructions](docker/rhel/README.md)
 
+### Packaging
+
+Only some of the container images provided support packaging.
+
 ## Tools images
 
 Aside from build images, XRPLF projects also use container images with specialized tools, e.g.

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -40,6 +40,7 @@ pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by provi
 pkgs+=(cmake)           # Required build tool.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
+pkgs+=(debhelper)       # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
 pkgs+=(git)             # Required build tool.
 pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -40,7 +40,6 @@ pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by provi
 pkgs+=(cmake)           # Required build tool.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
-pkgs+=(debhelper)       # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
 pkgs+=(git)             # Required build tool.
 pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
@@ -168,11 +167,19 @@ apt-get update
 apt-get install -t llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} -y --no-install-recommends clang-${CLANG_VERSION} llvm-${CLANG_VERSION}
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${CLANG_VERSION} 999
+update-alternatives --install \
+    /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION}
+update-alternatives --install \
+    /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-${CLANG_VERSION} 100
+update-alternatives --auto cc
+update-alternatives --auto clang
+update-alternatives --auto llvm-cov
 EOF
+
 ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
-# This is required by some build dependencies
-RUN update-alternatives --install /usr/bin/cc cc $CC 999
 
 # Check that the installed Clang version matches the expected version.
 RUN <<EOF

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -29,6 +29,12 @@ versions by specifying the `DEBIAN_VERSION` build argument. There are additional
 arguments to specify as well, namely `GCC_VERSION` for the GCC flavor and
 `CLANG_VERSION` for the Clang flavor.
 
+None of the build images support packaging, since (in order to be access the most
+recent official releases) the compilers are installed from external sources:
+
+* [gcc Docker Official Image](https://hub.docker.com/_/gcc)
+* [LLVM Debian/Ubuntu nightly packages](https://apt.llvm.org/)
+
 Run the commands below from the root directory of the repository.
 
 #### Building the Docker image for GCC.

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -35,9 +35,9 @@ recent official releases) the compilers are installed from external sources:
 * [gcc Docker Official Image](https://hub.docker.com/_/gcc)
 * [LLVM Debian/Ubuntu nightly packages](https://apt.llvm.org/)
 
-Run the commands below from the root directory of the repository.
+In order to build an image, run the commands below from the root directory of the repository.
 
-#### Building the Docker image for GCC.
+#### Building the Docker image for GCC
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.
@@ -61,7 +61,7 @@ docker buildx build . \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
 
-#### Building the Docker image for Clang.
+#### Building the Docker image for Clang
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -54,12 +54,14 @@ dnf clean -y all
 rm -rf /var/cache/dnf/*
 update-alternatives --install /usr/bin/cc cc /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc 999
 update-alternatives \
-    --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc ${GCC_VERSION} \
+    --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc 100 \
     --slave /usr/bin/g++ g++ /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/g++ \
     --slave /usr/bin/cpp cpp /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/cpp \
     --slave /usr/bin/gcov gcov /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcov \
     --slave /usr/bin/gcov-dump gcov-dump /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcov-dump-${GCC_VERSION} \
     --slave /usr/bin/gcov-tool gcov-tool /opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcov-tool-${GCC_VERSION}
+update-alternatives --auto cc
+update-alternatives --auto gcc
 EOF
 ENV CC=/usr/bin/gcc
 ENV CXX=/usr/bin/g++
@@ -139,11 +141,12 @@ RUN <<EOF
 dnf install -y --setopt=tsflags=nodocs clang llvm
 dnf clean -y all
 rm -rf /var/cache/dnf/*
+update-alternatives --install /usr/bin/cc cc /usr/bin/clang 999
+update-alternatives --auto cc
 EOF
+
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
-# This is required by some build dependencies
-RUN update-alternatives --install /usr/bin/cc cc $CC 999
 
 # Check that the installed Clang version is not older than the minimum required.
 ARG MINIMUM_CLANG_VERSION=16

--- a/docker/rhel/README.md
+++ b/docker/rhel/README.md
@@ -48,6 +48,8 @@ versions by specifying the `RHEL_VERSION` build argument. There are additional
 arguments to specify as well, namely `GCC_VERSION` for the GCC flavor and
 `CLANG_VERSION` for the Clang flavor.
 
+Both build images for `gcc` and `clang` support packaging.
+
 Run the commands below from the root directory of the repository.
 
 #### Building the Docker image for GCC.

--- a/docker/rhel/README.md
+++ b/docker/rhel/README.md
@@ -50,9 +50,9 @@ arguments to specify as well, namely `GCC_VERSION` for the GCC flavor and
 
 Both build images for `gcc` and `clang` support packaging.
 
-Run the commands below from the root directory of the repository.
+In order to build an image, run the commands below from the root directory of the repository.
 
-#### Building the Docker image for GCC.
+#### Building the Docker image for GCC
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.
@@ -76,7 +76,7 @@ docker buildx build . \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
 
-#### Building the Docker image for Clang.
+#### Building the Docker image for Clang
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -29,6 +29,7 @@ pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by provi
 pkgs+=(cmake)           # Required build tool.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
+pkgs+=(debhelper)       # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
 pkgs+=(git)             # Required build tool.
 pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
@@ -73,7 +74,6 @@ update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 999
 update-alternatives \
     --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} ${GCC_VERSION} \
     --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} \
-    --slave /usr/bin/cpp cpp /usr/bin/cpp-${GCC_VERSION} \
     --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} \
     --slave /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-${GCC_VERSION} \
     --slave /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${GCC_VERSION}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -29,7 +29,6 @@ pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by provi
 pkgs+=(cmake)           # Required build tool.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
-pkgs+=(debhelper)       # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
 pkgs+=(git)             # Required build tool.
 pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
@@ -61,22 +60,26 @@ FROM base AS gcc
 # This is not inherited from base image, ensure no manual interaction needed.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install GCC and create the necessary symlinks.
+# Install GCC and create the necessary symlinks. We only support packaging with
+# gcc because of the hard package dependencies from libtool to gcc
 ARG GCC_VERSION
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends \
     gcc-${GCC_VERSION} \
-    g++-${GCC_VERSION}
+    g++-${GCC_VERSION} \
+    debhelper
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 999
 update-alternatives \
-    --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} ${GCC_VERSION} \
+    --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} \
     --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} \
     --slave /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-${GCC_VERSION} \
     --slave /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${GCC_VERSION}
+update-alternatives --auto cc
+update-alternatives --auto gcc
 EOF
 ENV CC=/usr/bin/gcc
 ENV CXX=/usr/bin/g++
@@ -161,11 +164,19 @@ apt-get install -y --no-install-recommends \
     llvm-${CLANG_VERSION}
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${CLANG_VERSION} 999
+update-alternatives --install \
+    /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION}
+update-alternatives --install \
+    /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-${CLANG_VERSION} 100
+update-alternatives --auto cc
+update-alternatives --auto clang
+update-alternatives --auto llvm-cov
 EOF
+
 ENV CC=/usr/bin/clang-${CLANG_VERSION}
 ENV CXX=/usr/bin/clang++-${CLANG_VERSION}
-# This is required by some build dependencies
-RUN update-alternatives --install /usr/bin/cc cc $CC 999
 
 # Check that the installed Clang version matches the expected version.
 RUN <<EOF

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -31,9 +31,9 @@ and `CLANG_VERSION` for the Clang flavor.
 
 Build image for `gcc` supports packaging.
 
-Run the commands below from the root directory of the repository.
+In order to build an image, run the commands below from the root directory of the repository.
 
-#### Building the Docker image for GCC.
+#### Building the Docker image for GCC
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.
@@ -57,7 +57,7 @@ docker buildx build . \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
 
-#### Building the Docker image for Clang.
+#### Building the Docker image for Clang
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -29,6 +29,8 @@ future versions by specifying the `UBUNTU_VERSION` build argument. There are
 additional arguments to specify as well, namely `GCC_VERSION` for the GCC flavor
 and `CLANG_VERSION` for the Clang flavor.
 
+Build image for `gcc` supports packaging.
+
 Run the commands below from the root directory of the repository.
 
 #### Building the Docker image for GCC.


### PR DESCRIPTION
Add `debhelper` to Ubuntu `gcc` image, document packaging support for various images.