### PR TITLE
Add vim to all images

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -50,6 +50,7 @@ pkgs+=(ninja-build)     # Required build tool.
 pkgs+=(pipx)            # Package manager for Python applications.
 pkgs+=(python3-jinja2)  # Required build tool.
 pkgs+=(wget)            # Required build tool.
+pkgs+=(vim)             # Text editor.
 apt-get update
 apt-get install -y --no-install-recommends "${pkgs[@]}"
 apt-get clean

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -28,6 +28,7 @@ pkgs+=(python3-pip)      # Package manager for Python applications.
 pkgs+=(rpm-build)        # Required packaging tool.
 pkgs+=(rpmdevtools)      # Required packaging tool.
 pkgs+=(wget)             # Required build tool.
+pkgs+=(vim)              # Text editor.
 dnf install -y --allowerasing --setopt=tsflags=nodocs "${pkgs[@]}"
 dnf clean -y all
 rm -rf /var/cache/dnf/*

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -32,6 +32,7 @@ pkgs+=(gpg-agent)       # Dependency for tools requiring signing or encrypting/d
 pkgs+=(jq)              # Pretty printing.
 pkgs+=(pipx)            # Package manager for Python applications.
 pkgs+=(wget)            # Required build tool.
+pkgs+=(vim)             # Text editor.
 apt-get update
 apt-get install -y --no-install-recommends "${pkgs[@]}"
 apt-get clean

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -39,6 +39,7 @@ pkgs+=(ninja-build)     # Required build tool.
 pkgs+=(pipx)            # Package manager for Python applications.
 pkgs+=(python3-jinja2)  # Required build tool.
 pkgs+=(wget)            # Required build tool.
+pkgs+=(vim)             # Text editor.
 apt-get update
 apt-get install -y --no-install-recommends "${pkgs[@]}"
 apt-get clean


### PR DESCRIPTION
When troubleshooting CI related issues, it is **really** useful to have a text editor handy.

We could select something smaller than `vim` (which is 55MB in Debian/Ubuntu 😢 ) but with a similar user interface, for example `nvi` but then RHEL does not have it, or we could select something smaller than `vim` but wit a non-standard UI like `joe` or `nano`, but if you are troubleshooting build issues you probably also know `vi` or `vim` better than the other two.