### PR TITLE
Cleanup CI images, add distro release and version

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -7,6 +7,14 @@ on:
       - docker/debian/Dockerfile
       - test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   BUILDKIT_PROGRESS: plain
@@ -114,7 +122,6 @@ jobs:
           target: ${{ matrix.os.compiler_name }}
       - name: Export digest
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
-        shell: bash
         run: |
           mkdir -p /tmp/digests
           DIGEST="${{ steps.build.outputs.digest }}"
@@ -196,13 +203,11 @@ jobs:
             type=sha,prefix=${{ matrix.os.compiler_name }}-${{ matrix.os.compiler_version }}-sha-
       - name: Create manifest list and push
         working-directory: /tmp/digests
-        shell: bash
         run: |
           eval "docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.CONTAINER_IMAGE }}@sha256:%s ' *)"
       - name: Inspect image
-        shell: bash
         run: |
           docker buildx imagetools inspect ${{ env.CONTAINER_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -7,6 +7,14 @@ on:
       - docker/rhel/Dockerfile
       - test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   REDHAT_REGISTRY: registry.redhat.io
@@ -104,7 +112,6 @@ jobs:
           target: ${{ matrix.os.compiler_name }}
       - name: Export digest
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
-        shell: bash
         run: |
           mkdir -p /tmp/digests
           DIGEST="${{ steps.build.outputs.digest }}"
@@ -171,13 +178,11 @@ jobs:
             type=sha,prefix=${{ matrix.os.compiler_name }}-${{ matrix.os.compiler_version }}-sha-
       - name: Create manifest list and push
         working-directory: /tmp/digests
-        shell: bash
         run: |
           eval "docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.CONTAINER_IMAGE }}@sha256:%s ' *)"
       - name: Inspect image
-        shell: bash
         run: |
           docker buildx imagetools inspect ${{ env.CONTAINER_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -6,6 +6,14 @@ on:
       - .github/workflows/tools-rippled.yml
       - docker/tools-rippled/Dockerfile
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   BUILDKIT_PROGRESS: plain
@@ -84,7 +92,6 @@ jobs:
           target: ${{ matrix.tool }}
       - name: Export digest
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
-        shell: bash
         run: |
           mkdir -p /tmp/digests
           DIGEST="${{ steps.build.outputs.digest }}"
@@ -143,13 +150,11 @@ jobs:
             type=raw,value=latest
       - name: Create manifest list and push
         working-directory: /tmp/digests
-        shell: bash
         run: |
           eval "docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.CONTAINER_IMAGE }}@sha256:%s ' *)"
       - name: Inspect image
-        shell: bash
         run: |
           docker buildx imagetools inspect ${{ env.CONTAINER_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,6 +7,14 @@ on:
       - docker/ubuntu/Dockerfile
       - test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CONTAINER_REGISTRY: ghcr.io
   BUILDKIT_PROGRESS: plain
@@ -112,7 +120,6 @@ jobs:
           target: ${{ matrix.os.compiler_name }}
       - name: Export digest
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
-        shell: bash
         run: |
           mkdir -p /tmp/digests
           DIGEST="${{ steps.build.outputs.digest }}"
@@ -191,13 +198,11 @@ jobs:
             type=sha,prefix=${{ matrix.os.compiler_name }}-${{ matrix.os.compiler_version }}-sha-
       - name: Create manifest list and push
         working-directory: /tmp/digests
-        shell: bash
         run: |
           eval "docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.CONTAINER_IMAGE }}@sha256:%s ' *)"
       - name: Inspect image
-        shell: bash
         run: |
           docker buildx imagetools inspect ${{ env.CONTAINER_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -131,7 +131,7 @@ EOF
 # Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
-tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
+tools.info.package_id:confs+=["Debian", "${DEBIAN_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -212,7 +212,7 @@ EOF
 # Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
-tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
+tools.info.package_id:confs+=["Debian", "${DEBIAN_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -116,10 +116,10 @@ if [[ "${CXX_VER}" != "${GCC_VERSION}" ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -128,14 +128,14 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
+
 # Print the Conan profile to verify the configuration.
 RUN conan profile show
 
@@ -197,10 +197,10 @@ if [[ "${CXX_VER}" != "${CLANG_VERSION}" ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -209,16 +209,10 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags. To ensure compatibility with a range of
-# Clang compilers, we must also add extra flags that apply to certain versions
-# of Clang.
-# TODO: Move extra flags into the rippled repository as a custom Conan profile.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
-CXX_VER=$(${CXX} -dumpversion)
-CXX_VER=${CXX_VER%%.*}
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -82,10 +82,10 @@ if [[ "${CXX_VER}" != "${GCC_VERSION}" ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -94,11 +94,10 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -147,10 +146,10 @@ if [[ ${CXX_VER} -lt ${MINIMUM_CLANG_VERSION} ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -159,16 +158,10 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags. To ensure compatibility with a range of
-# Clang compilers, we must also add extra flags that apply to certain versions
-# of Clang.
-# TODO: Move extra flags into the rippled repository as a custom Conan profile.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
-CXX_VER=$(${CXX} -dumpversion)
-CXX_VER=${CXX_VER%%.*}
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -100,10 +100,10 @@ if [[ "${CXX_VER}" != "${GCC_VERSION}" ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -112,11 +112,10 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -177,10 +176,10 @@ if [[ "${CXX_VER}" != "${CLANG_VERSION}" ]]; then
 fi
 EOF
 
+# Set the Conan home directory, so the users of this image can find the default
+# profile.
 ENV HOME=/root
 WORKDIR ${HOME}
-
-# Set Conan home directory, so the users of this image can find default profile
 ENV CONAN_HOME=${HOME}/.conan2
 
 # Create a default Conan profile.
@@ -189,16 +188,10 @@ conan profile detect
 rm -rf /tmp/*
 EOF
 
-# Fix the C++ dialect.
-RUN sed -i -e 's|^compiler\.cppstd=.*$|compiler.cppstd=20|' $(conan config home)/profiles/default
-# Explicitly set the compiler flags. To ensure compatibility with a range of
-# Clang compilers, we must also add extra flags that apply to certain versions
-# of Clang.
-# TODO: Move extra flags into the rippled repository as a custom Conan profile.
+# Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
-CXX_VER=$(${CXX} -dumpversion)
-CXX_VER=${CXX_VER%%.*}
 cat >> $(conan config home)/global.conf <<EOT
+tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -115,7 +115,7 @@ EOF
 # Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
-tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
+tools.info.package_id:confs+=["Ubuntu", "${UBUNTU_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF
@@ -191,7 +191,7 @@ EOF
 # Explicitly set the compiler flags and the distribution name and version.
 RUN <<EOF
 cat >> $(conan config home)/global.conf <<EOT
-tools.info.package_id:confs+=["RHEL", "${RHEL_VERSION}"]
+tools.info.package_id:confs+=["Ubuntu", "${UBUNTU_VERSION}"]
 tools.build:compiler_executables={"c": "${CC}", "cpp": "${CXX}"}
 EOT
 EOF


### PR DESCRIPTION
* Replaces `shell: bash` in each step by setting the shell in `defaults`.
* Uses the concurrency group to stop building an image when a new commit is added.
* Removes setting the `compiler.cppstd=20` option as that is now provided by the default Conan profile in the rippled repo.
* Removes the TODOs since they have been addressed.
* Removes unused `CXX_VER`.
* Adds the distro release and version to the Conan configuration that affects generating the package IDs.