### PR TITLE
Add documentation tools image

### DIFF
--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -32,6 +32,7 @@ jobs:
             runner: ubuntu-24.04-arm
         tool:
           - clang-format
+          - documentation
     runs-on: ${{ matrix.architecture.runner }}
     permissions:
       packages: write
@@ -111,6 +112,7 @@ jobs:
       matrix:
         tool:
           - clang-format
+          - documentation
     runs-on: ubuntu-24.04
     needs:
       - build

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -43,7 +43,7 @@ ENV PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/bin \
     PIPX_MAN_DIR=/usr/share/man
 
-# ====================== clang-format IMAGE ======================
+# ====================== CLANG-FORMAT IMAGE ======================
 # Note, we do not install a compiler here.
 
 FROM base AS clang-format
@@ -57,6 +57,26 @@ ARG CLANG_FORMAT_VERSION
 ARG PRE_COMMIT_VERSION
 RUN pipx install --pip-args='--no-cache' clang-format==${CLANG_FORMAT_VERSION} && \
     pipx install --pip-args='--no-cache' pre-commit==${PRE_COMMIT_VERSION}
+
+ENV HOME=/root
+WORKDIR ${HOME}
+
+# ====================== DOCUMENTATION IMAGE ======================
+# Note, we do not install a compiler here.
+
+FROM base AS documentation
+
+# These are not inherited from base image.
+ARG UBUNTU_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install doxygen and graphviz.
+RUN <<EOF
+apt-get update
+apt-get install -y doxygen graphviz
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
 
 ENV HOME=/root
 WORKDIR ${HOME}


### PR DESCRIPTION
Upon merging a PR in the `rippled` repository, documentation is built and published. We are currently using an older image in the `rippled` CI pipeline that is not hosted in this repo. This PR adds the image containing the necessary `doxygen` and `graphviz` tools.