### PR TITLE
Add Python 3.12 to RHEL image

### DIFF
--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -7,9 +7,6 @@ FROM registry.redhat.io/ubi${RHEL_VERSION%.*}/s2i-base:${RHEL_VERSION} AS base
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENTRYPOINT ["/bin/bash"]
 
-# Update the packages installed on the system.
-RUN dnf update -y
-
 # Install tools that are shared by all stages.
 RUN <<EOF
 pkgs=()
@@ -24,12 +21,13 @@ pkgs+=(libstdc++-static) # Required to statically link libraries into rippled.
 pkgs+=(ninja-build)      # Required build tool.
 pkgs+=(perl-FindBin)     # Required to compile OpenSSL.
 pkgs+=(python3.12)       # Required build tool.
+pkgs+=(python3.12-pip)   # Package manager for Python applications.
 pkgs+=(python3-jinja2)   # Required build tool.
-pkgs+=(python3-pip)      # Package manager for Python applications.
 pkgs+=(rpm-build)        # Required packaging tool.
 pkgs+=(rpmdevtools)      # Required packaging tool.
 pkgs+=(vim)              # Text editor.
 pkgs+=(wget)             # Required build tool.
+dnf update -y
 dnf install -y --allowerasing --setopt=tsflags=nodocs "${pkgs[@]}"
 dnf clean -y all
 rm -rf /var/cache/dnf/*
@@ -41,6 +39,8 @@ ln -sf /usr/bin/python3.12 /usr/bin/python3
 ln -sf /usr/bin/python3.12 /usr/bin/python
 ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc3
 ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc
+ln -sf /usr/bin/pip3.12 /usr/bin/pip3
+ln -sf /usr/bin/pip3.12 /usr/bin/pip
 EOF
 
 # Install Python-based tools.

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -33,7 +33,7 @@ dnf clean -y all
 rm -rf /var/cache/dnf/*
 EOF
 
-# Update the `python3` symlink to point to the latest Python 3 version.
+# Update the symlinks to point to the latest Python versions.
 RUN <<EOF
 ln -sf /usr/bin/python3.12 /usr/bin/python3
 ln -sf /usr/bin/python3.12 /usr/bin/python

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -44,6 +44,8 @@ ln -sf /usr/bin/pydoc3.12 /usr/local/bin/pydoc3
 ln -sf /usr/bin/pydoc3.12 /usr/local/bin/pydoc
 ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3
 ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
+mkdir -p /usr/local/lib
+ln -sf /usr/lib/python3.12 /usr/local/lib/python3.12
 EOF
 
 # Install Python-based tools.

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENTRYPOINT ["/bin/bash"]
 
 # Update the packages installed on the system.
-RUN dnf update-minimal -y --security --sec-severity=Important --sec-severity=Critical
+RUN dnf update -y
 
 # Install tools that are shared by all stages.
 RUN <<EOF
@@ -23,6 +23,7 @@ pkgs+=(jq)               # JSON manipulation.
 pkgs+=(libstdc++-static) # Required to statically link libraries into rippled.
 pkgs+=(ninja-build)      # Required build tool.
 pkgs+=(perl-FindBin)     # Required to compile OpenSSL.
+pkgs+=(python3.12)       # Required build tool.
 pkgs+=(python3-jinja2)   # Required build tool.
 pkgs+=(python3-pip)      # Package manager for Python applications.
 pkgs+=(rpm-build)        # Required packaging tool.
@@ -32,6 +33,14 @@ pkgs+=(wget)             # Required build tool.
 dnf install -y --allowerasing --setopt=tsflags=nodocs "${pkgs[@]}"
 dnf clean -y all
 rm -rf /var/cache/dnf/*
+EOF
+
+# Update the `python3` symlink to point to the latest Python 3 version.
+RUN <<EOF
+ln -sf /usr/bin/python3.12 /usr/bin/python3
+ln -sf /usr/bin/python3.12 /usr/bin/python
+ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc3
+ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc
 EOF
 
 # Install Python-based tools.

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -33,14 +33,17 @@ dnf clean -y all
 rm -rf /var/cache/dnf/*
 EOF
 
-# Update the symlinks to point to the latest Python versions.
+# Add symlinks to point to the latest Python versions. The /usr/local/bin
+# directory is in the PATH before the /usr/bin directory, so the new Python
+# versions will be used by default.
 RUN <<EOF
-ln -sf /usr/bin/python3.12 /usr/bin/python3
-ln -sf /usr/bin/python3.12 /usr/bin/python
-ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc3
-ln -sf /usr/bin/pydoc3.12 /usr/bin/pydoc
-ln -sf /usr/bin/pip3.12 /usr/bin/pip3
-ln -sf /usr/bin/pip3.12 /usr/bin/pip
+mkdir -p /usr/local/bin
+ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+ln -sf /usr/bin/python3.12 /usr/local/bin/python
+ln -sf /usr/bin/pydoc3.12 /usr/local/bin/pydoc3
+ln -sf /usr/bin/pydoc3.12 /usr/local/bin/pydoc
+ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3
+ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
 EOF
 
 # Install Python-based tools.


### PR DESCRIPTION
The Python version that comes with the RHEL image is 3.9, which has almost reached its EOL. This change adds Python 3.12 - the latest version available via the package manager - and updates the symlinks to switch to this new version.