### PR TITLE
Switch to RHEL UBI image, add 9.4

### DIFF
--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -35,12 +35,18 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
         os:
+          - release: 9.4
+            compiler_name: gcc
+            compiler_version: 12
           - release: 9.6
             compiler_name: gcc
             compiler_version: 13
           - release: 9.6
             compiler_name: gcc
             compiler_version: 14
+          - release: 9.4
+            compiler_name: clang
+            compiler_version: 'any'
           - release: 9.6
             compiler_name: clang
             compiler_version: 'any'

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -1,6 +1,6 @@
 # ====================== BASE IMAGE ======================
 ARG RHEL_VERSION
-FROM registry.redhat.io/ubi${RHEL_VERSION%.*}/s2i-base:${RHEL_VERSION} AS base
+FROM registry.redhat.io/ubi${RHEL_VERSION%.*}/ubi:${RHEL_VERSION} AS base
 
 # Use Bash as the default shell for RUN commands, using the options
 # `set -o errexit -o pipefail`, and as the entrypoint.

--- a/docker/rhel/README.md
+++ b/docker/rhel/README.md
@@ -44,9 +44,10 @@ docker login ${CONTAINER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
 ### Building and pushing the Docker image
 
 The same Dockerfile can be used to build an image for RHEL 9.6 or future
-versions by specifying the `RHEL_VERSION` build argument. There are additional
-arguments to specify as well, namely `GCC_VERSION` for the GCC flavor and
-`CLANG_VERSION` for the Clang flavor.
+versions by specifying the `RHEL_VERSION` build argument. There is an additional
+argument to specify as well, namely `GCC_VERSION` for the GCC flavor; in the
+RHEL images we cannot choose the Clang version to install, so the Clang version
+is set to "any".
 
 Both build images for `gcc` and `clang` support packaging.
 
@@ -86,7 +87,7 @@ registry.
 RHEL_VERSION=9.6
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
-CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:clang-${CLANG_VERSION}
+CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:clang-any
 
 docker buildx build . \
   --file docker/rhel/Dockerfile \


### PR DESCRIPTION
For creating the RHEL images, I originally used the RHEL `s2i-base` image as base, thinking it contained vital tools needed to create derived builder images, such as ours. However, looking more closely, `s2i-base` is based on `s2i-core`, which in turn is based on `ubi`. Rebuilding the image using the latter image works perfectly fine, making it thus even smaller than before.

As an added bonus, there is no 9.4 tag for the `s2i-*` images, but exists for `ubi`. Hence, this PR also adds an image for RHEL 9.4 using the lowest GCC we support - 12 - and the default Clang that is available via the package manager.