### PR TITLE
Add rippled-tools image containing Prettier for file formatting

### DIFF
--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -24,6 +24,7 @@ env:
   GCC_VERSION: 14
   GRAPHVIZ_VERSION: 2.42.2-9ubuntu0.1
   NODE_VERSION: 24.5.0
+  NPM_VERSION: 11.5.2
   NVM_VERSION: 0.40.3
   PRETTIER_VERSION: 3.6.2
   PRE_COMMIT_VERSION: 4.2.0
@@ -96,6 +97,7 @@ jobs:
             GCC_VERSION=${{ env.GCC_VERSION }}
             GRAPHVIZ_VERSION=${{ env.GRAPHVIZ_VERSION }}
             NODE_VERSION=${{ env.NODE_VERSION }}
+            NPM_VERSION=${{ env.NPM_VERSION }}
             NVM_VERSION=${{ env.NVM_VERSION }}
             PRETTIER_VERSION=${{ env.PRETTIER_VERSION }}
             PRE_COMMIT_VERSION=${{ env.PRE_COMMIT_VERSION }}

--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -21,6 +21,9 @@ env:
   PRE_COMMIT_VERSION: 4.2.0
   DOXYGEN_VERSION: 1.9.8+ds-2build5
   GRAPHVIZ_VERSION: 2.42.2-9ubuntu0.1
+  NODE_VERSION: 24.5.0
+  NVM_VERSION: 0.40.3
+  PRETTIER_VERSION: 3.6.2
   UBUNTU_VERSION: noble
 
 jobs:
@@ -35,6 +38,7 @@ jobs:
         tool:
           - clang-format
           - documentation
+          - prettier
     runs-on: ${{ matrix.architecture.runner }}
     permissions:
       packages: write
@@ -87,6 +91,9 @@ jobs:
             PRE_COMMIT_VERSION=${{ env.PRE_COMMIT_VERSION }}
             DOXYGEN_VERSION=${{ env.DOXYGEN_VERSION }}
             GRAPHVIZ_VERSION=${{ env.GRAPHVIZ_VERSION }}
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            NVM_VERSION=${{ env.NVM_VERSION }}
+            PRETTIER_VERSION=${{ env.PRETTIER_VERSION }}
           context: docker/tools-rippled
           outputs: type=image,name=${{ env.CONTAINER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.architecture.platform }}
@@ -117,6 +124,7 @@ jobs:
         tool:
           - clang-format
           - documentation
+          - prettier
     runs-on: ubuntu-24.04
     needs:
       - build

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -128,15 +128,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install node and npm via nvm, and then install prettier, see also
 # https://nodejs.org/en/download.
-ARG NVM_VERSION
 ARG NODE_VERSION
+ARG NPM_VERSION
+ARG NVM_VERSION
 ARG PRETTIER_VERSION
+ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org
 RUN <<EOF
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
 \. "${HOME}/.nvm/nvm.sh"
 nvm install ${NODE_VERSION}
-export NPM_CONFIG_REGISTRY=https://registry.npmjs.org
-npm install -g --no-audit --no-fund npm@latest
+npm install -g --no-audit --no-fund npm@${NPM_VERSION}
 npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
 npm cache clean --force
 EOF

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -49,8 +49,7 @@ ENV PIPX_HOME=/opt/pipx \
 
 FROM base AS clang-format
 
-# These are not inherited from base image.
-ARG UBUNTU_VERSION
+# This is not inherited from base image.
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install clang-format.
@@ -67,8 +66,7 @@ WORKDIR ${HOME}
 
 FROM base AS documentation
 
-# These are not inherited from base image.
-ARG UBUNTU_VERSION
+# This is not inherited from base image.
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install doxygen and graphviz.
@@ -79,6 +77,31 @@ apt-get update
 apt-get install -y doxygen=${DOXYGEN_VERSION} graphviz=${GRAPHVIZ_VERSION}
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+EOF
+
+ENV HOME=/root
+WORKDIR ${HOME}
+
+# ====================== PRETTIER IMAGE ======================
+# Note, we do not install a compiler here.
+
+FROM base AS prettier
+
+# This is not inherited from base image.
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install node and npm via nvm, and then install prettier, see also
+# https://nodejs.org/en/download.
+ARG NVM_VERSION
+ARG NODE_VERSION
+ARG PRETTIER_VERSION
+RUN <<EOF
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
+\. "${HOME}/.nvm/nvm.sh"
+nvm install ${NODE_VERSION}
+# Update npm to the latest version.
+npm install -g npm@${NPM_VERSION} --registry=https://registry.npmjs.org
+npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
 EOF
 
 ENV HOME=/root

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -102,6 +102,7 @@ nvm install ${NODE_VERSION}
 export NPM_CONFIG_REGISTRY=https://registry.npmjs.org
 npm install -g --no-audit --no-fund npm@latest
 npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
+npm cache clean --force
 EOF
 
 ENV HOME=/root

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -99,8 +99,8 @@ RUN <<EOF
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
 \. "${HOME}/.nvm/nvm.sh"
 nvm install ${NODE_VERSION}
-# Update npm to the latest version.
-npm install -g npm@${NPM_VERSION} --registry=https://registry.npmjs.org
+export NPM_CONFIG_REGISTRY=https://registry.npmjs.org
+npm install -g --no-audit --no-fund npm@latest
 npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
 EOF
 

--- a/docker/tools-rippled/README.md
+++ b/docker/tools-rippled/README.md
@@ -78,6 +78,30 @@ docker buildx build . \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
 
+#### Building the Docker image for prettier
+
+Ensure you've run the login command above to authenticate with the Docker
+registry.
+
+```shell
+UBUNTU_VERSION=noble
+NODE_VERSION=24.5.0
+NVM_VERSION=0.40.3
+PRETTIER_VERSION=3.6.2
+CONTAINER_IMAGE=xrplf/ci/tools-rippled-prettier:latest
+
+docker buildx build . \
+  --file docker/tools-rippled/Dockerfile \
+  --target prettier \
+  --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=InvalidDefaultArgInFrom \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg NODE_VERSION=${NODE_VERSION} \
+  --build-arg NVM_VERSION=${NVM_VERSION} \
+  --build-arg PRETTIER_VERSION=${PRETTIER_VERSION} \
+  --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
+  --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
+```
+
 #### Pushing the Docker image to the GitHub registry
 
 If you want to push the image to the GitHub registry, you can do so with the

--- a/docker/tools-rippled/README.md
+++ b/docker/tools-rippled/README.md
@@ -90,6 +90,7 @@ registry.
 ```shell
 UBUNTU_VERSION=noble
 NODE_VERSION=24.5.0
+NPM_VERSION=11.5.2
 NVM_VERSION=0.40.3
 PRETTIER_VERSION=3.6.2
 CONTAINER_IMAGE=xrplf/ci/tools-rippled-prettier:latest
@@ -100,6 +101,7 @@ docker buildx build . \
   --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=InvalidDefaultArgInFrom \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg NODE_VERSION=${NODE_VERSION} \
+  --build-arg NPM_VERSION=${NPM_VERSION} \
   --build-arg NVM_VERSION=${NVM_VERSION} \
   --build-arg PRETTIER_VERSION=${PRETTIER_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \


### PR DESCRIPTION
To avoid having to set up Node.JS, NPM, and install Prettier from scratch each time, this PR creates a new `tools-rippled-prettier` image with everything already configured.

See https://github.com/XRPLF/rippled/pull/5665 for where it will be used.