### PR TITLE
Add `workflow_dispatch:` to all workflows

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/debian.yml
       - docker/debian/Dockerfile
       - test
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/rhel.yml
       - docker/rhel/Dockerfile
       - test
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/tools-rippled.yml
       - docker/tools-rippled/Dockerfile
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/ubuntu.yml
       - docker/ubuntu/Dockerfile
       - test
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This is to enable us to rebuild container images on demand.