### PR TITLE
Add Debian Bookworm image with GCC 15

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -154,6 +154,9 @@ jobs:
             compiler_name: gcc
             compiler_version: 14
           - release: bookworm
+            compiler_name: gcc
+            compiler_version: 15
+          - release: bookworm
             compiler_name: clang
             compiler_version: 16
           - release: bookworm


### PR DESCRIPTION
Forgot to add GCC 15 to `merge` job in #34 , so another PR is needed.