### PR TITLE
Replace `pipx` with `pip` + `venv`, install `cmake` with `pip`

### DIFF
--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -22,6 +22,7 @@ env:
   BUILDKIT_PROGRESS: plain
   CONAN_VERSION: 2.19.1
   GCOVR_VERSION: 8.3
+  CMAKE_VERSION: 3.31.6
 
 jobs:
   # Build the Docker image for Red Hat Enterprise Linux using different versions
@@ -113,6 +114,7 @@ jobs:
             CONAN_VERSION=${{ env.CONAN_VERSION }}
             GCC_VERSION=${{ matrix.os.compiler_version }}
             GCOVR_VERSION=${{ env.GCOVR_VERSION }}
+            CMAKE_VERSION=${{ env.CMAKE_VERSION }}
             RHEL_VERSION=${{ matrix.os.release }}
           context: .
           file: docker/rhel/Dockerfile

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,7 @@ env:
   BUILDKIT_PROGRESS: plain
   CONAN_VERSION: 2.19.1
   GCOVR_VERSION: 8.3
+  CMAKE_VERSION: 3.31.6
   FALLBACK_GCC: 12
   FALLBACK_CLANG: 16
 
@@ -109,6 +110,7 @@ jobs:
             CONAN_VERSION=${{ env.CONAN_VERSION }}
             GCC_VERSION=${{ matrix.os.compiler_name == 'gcc' && matrix.os.compiler_version || env.FALLBACK_GCC }}
             GCOVR_VERSION=${{ env.GCOVR_VERSION }}
+            CMAKE_VERSION=${{ env.CMAKE_VERSION }}
             UBUNTU_VERSION=${{ matrix.os.release }}
           context: .
           file: docker/ubuntu/Dockerfile

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -57,7 +57,7 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 
-# Install Python-based tools.
+# Install Python-based tools and cmake.
 ARG CONAN_VERSION
 ARG GCOVR_VERSION
 ARG CMAKE_VERSION

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -11,7 +11,6 @@ ENTRYPOINT ["/bin/bash"]
 RUN <<EOF
 pkgs=()
 pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-pkgs+=(cmake)             # Required build tool.
 pkgs+=(file)              # Required packaging tool.
 pkgs+=(git)               # Required build tool.
 pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
@@ -23,7 +22,6 @@ pkgs+=(perl-FindBin)      # Required to compile OpenSSL.
 pkgs+=(perl-File-Compare) # Required to compile OpenSSL.
 pkgs+=(python3.12)        # Required build tool.
 pkgs+=(python3.12-pip)    # Package manager for Python applications.
-pkgs+=(python3-jinja2)    # Required build tool.
 pkgs+=(rpm-build)         # Required packaging tool.
 pkgs+=(rpmdevtools)       # Required packaging tool.
 pkgs+=(vim)               # Text editor.
@@ -49,10 +47,18 @@ mkdir -p /usr/local/lib
 ln -sf /usr/lib/python3.12 /usr/local/lib/python3.12
 EOF
 
-# Install Python-based tools.
+# Install Python-based tools and cmake.
 ARG CONAN_VERSION
 ARG GCOVR_VERSION
-RUN pip install --no-cache conan==${CONAN_VERSION} gcovr==${GCOVR_VERSION}
+ARG CMAKE_VERSION
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+RUN pip install --no-cache \
+  conan==${CONAN_VERSION} \
+  gcovr==${GCOVR_VERSION} \
+  cmake==${CMAKE_VERSION}
 
 # ====================== GCC IMAGE ======================
 FROM base AS gcc

--- a/docker/rhel/README.md
+++ b/docker/rhel/README.md
@@ -64,6 +64,7 @@ RHEL_VERSION=9.6
 GCC_VERSION=13
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
+CMAKE_VERSION=3.31.6
 CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:gcc-${GCC_VERSION}
 
 docker buildx build . \
@@ -74,6 +75,7 @@ docker buildx build . \
   --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --build-arg GCC_VERSION=${GCC_VERSION} \
   --build-arg GCOVR_VERSION=${GCOVR_VERSION} \
+  --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
   --build-arg RHEL_VERSION=${RHEL_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
@@ -87,6 +89,7 @@ registry.
 RHEL_VERSION=9.6
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
+CMAKE_VERSION=3.31.6
 CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:clang-any
 
 docker buildx build . \
@@ -96,6 +99,7 @@ docker buildx build . \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --build-arg GCOVR_VERSION=${GCOVR_VERSION} \
+  --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
   --build-arg RHEL_VERSION=${RHEL_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -31,7 +31,8 @@ pkgs+=(git)             # Required build tool.
 pkgs+=(gpg)             # Dependency for tools requiring signing or encrypting/decrypting.
 pkgs+=(gpg-agent)       # Dependency for tools requiring signing or encrypting/decrypting.
 pkgs+=(jq)              # Pretty printing.
-pkgs+=(pipx)            # Package manager for Python applications.
+pkgs+=(python3-venv)    # Python environment management tool.
+pkgs+=(python3-pip)     # Package manager for Python applications.
 pkgs+=(wget)            # Required build tool.
 pkgs+=(vim)             # Text editor.
 apt-get update
@@ -40,9 +41,10 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 
-ENV PIPX_HOME=/opt/pipx \
-    PIPX_BIN_DIR=/usr/bin \
-    PIPX_MAN_DIR=/usr/share/man
+# Prepare the environment for Python-based tools.
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 
 # ====================== CLANG-FORMAT IMAGE ======================
 # Note, we do not install a compiler here.
@@ -56,8 +58,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install clang-format.
 ARG CLANG_FORMAT_VERSION
 ARG PRE_COMMIT_VERSION
-RUN pipx install --pip-args='--no-cache' clang-format==${CLANG_FORMAT_VERSION} && \
-    pipx install --pip-args='--no-cache' pre-commit==${PRE_COMMIT_VERSION}
+RUN pip install --no-cache \
+    clang-format==${CLANG_FORMAT_VERSION} \
+    pre-commit==${PRE_COMMIT_VERSION}
 
 ENV HOME=/root
 WORKDIR ${HOME}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -26,7 +26,6 @@ EOF
 RUN <<EOF
 pkgs=()
 pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
-pkgs+=(cmake)           # Required build tool.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
@@ -36,8 +35,8 @@ pkgs+=(gpg-agent)       # Dependency for tools requiring signing or encrypting/d
 pkgs+=(jq)              # JSON manipulation.
 pkgs+=(libc6-dev)       # Required build tool.
 pkgs+=(ninja-build)     # Required build tool.
-pkgs+=(pipx)            # Package manager for Python applications.
-pkgs+=(python3-jinja2)  # Required build tool.
+pkgs+=(python3-venv)    # Python environment management tool.
+pkgs+=(python3-pip)     # Package manager for Python applications.
 pkgs+=(vim)             # Text editor.
 pkgs+=(wget)            # Required build tool.
 apt-get update
@@ -46,14 +45,18 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 
-# Install Python-based tools.
+# Install Python-based tools and cmake.
 ARG CONAN_VERSION
 ARG GCOVR_VERSION
-ENV PIPX_HOME=/opt/pipx \
-    PIPX_BIN_DIR=/usr/bin \
-    PIPX_MAN_DIR=/usr/share/man
-RUN pipx install --pip-args='--no-cache' conan==${CONAN_VERSION} && \
-    pipx install --pip-args='--no-cache' gcovr==${GCOVR_VERSION}
+ARG CMAKE_VERSION
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+RUN pip install --no-cache \
+  conan==${CONAN_VERSION} \
+  gcovr==${GCOVR_VERSION} \
+  cmake==${CMAKE_VERSION}
 
 # ====================== GCC IMAGE ======================
 FROM base AS gcc

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -44,6 +44,7 @@ UBUNTU_VERSION=noble
 GCC_VERSION=14
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
+CMAKE_VERSION=3.31.6
 CONTAINER_IMAGE=xrplf/ci/ubuntu-${UBUNTU_VERSION}:gcc-${GCC_VERSION}
 
 docker buildx build . \
@@ -54,6 +55,7 @@ docker buildx build . \
   --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --build-arg GCC_VERSION=${GCC_VERSION} \
   --build-arg GCOVR_VERSION=${GCOVR_VERSION} \
+  --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
@@ -68,6 +70,7 @@ UBUNTU_VERSION=noble
 CLANG_VERSION=18
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
+CMAKE_VERSION=3.31.6
 CONTAINER_IMAGE=xrplf/ci/ubuntu-${UBUNTU_VERSION}:clang-${CLANG_VERSION}
 
 docker buildx build . \
@@ -78,6 +81,7 @@ docker buildx build . \
   --build-arg CLANG_VERSION=${CLANG_VERSION} \
   --build-arg CONAN_VERSION=${CONAN_VERSION} \
   --build-arg GCOVR_VERSION=${GCOVR_VERSION} \
+  --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```


### PR DESCRIPTION
This is for consistency with Debian images, where we were forced to do similar change for reasons of compatibility with Bullseye in #37 