### PR TITLE
Add cmake and gcc to documentation image

### DIFF
--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -19,9 +19,11 @@ env:
   CONTAINER_REGISTRY: ghcr.io
   BUILDKIT_PROGRESS: plain
   CLANG_FORMAT_VERSION: 18.1.8
-  PRE_COMMIT_VERSION: 4.2.0
+  CMAKE_VERSION: 3.31.6
   DOXYGEN_VERSION: 1.9.8+ds-2build5
+  GCC_VERSION: 14
   GRAPHVIZ_VERSION: 2.42.2-9ubuntu0.1
+  PRE_COMMIT_VERSION: 4.2.0
   UBUNTU_VERSION: noble
 
 jobs:
@@ -85,9 +87,11 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
             UBUNTU_VERSION=${{ env.UBUNTU_VERSION }}
             CLANG_FORMAT_VERSION=${{ env.CLANG_FORMAT_VERSION }}
-            PRE_COMMIT_VERSION=${{ env.PRE_COMMIT_VERSION }}
+            CMAKE_VERSION=${{ env.CMAKE_VERSION }}
             DOXYGEN_VERSION=${{ env.DOXYGEN_VERSION }}
+            GCC_VERSION=${{ env.GCC_VERSION }}
             GRAPHVIZ_VERSION=${{ env.GRAPHVIZ_VERSION }}
+            PRE_COMMIT_VERSION=${{ env.PRE_COMMIT_VERSION }}
           context: docker/tools-rippled
           outputs: type=image,name=${{ env.CONTAINER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.architecture.platform }}

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -66,13 +66,47 @@ ENV HOME=/root
 WORKDIR ${HOME}
 
 # ====================== DOCUMENTATION IMAGE ======================
-# Note, we do not install a compiler here.
 
 FROM base AS documentation
 
 # These are not inherited from base image.
 ARG UBUNTU_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
+
+# Install cmake, required to build the `docs` target.
+ARG CMAKE_VERSION
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+RUN pip install --no-cache cmake==${CMAKE_VERSION}
+
+# Install GCC and create the necessary symlinks.
+ARG GCC_VERSION
+RUN <<EOF
+apt-get update
+apt-get install -y --no-install-recommends \
+  gcc-${GCC_VERSION} \
+  g++-${GCC_VERSION} \
+  debhelper
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+update-alternatives \
+  --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 999
+update-alternatives \
+  --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 999
+update-alternatives \
+  --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+  --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} \
+  --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} \
+  --slave /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-${GCC_VERSION} \
+  --slave /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${GCC_VERSION}
+update-alternatives --auto cc
+update-alternatives --auto c++
+update-alternatives --auto gcc
+EOF
+# Set the compiler environment variables to point to the GCC binaries.
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
 
 # Install doxygen and graphviz.
 ARG DOXYGEN_VERSION

--- a/docker/tools-rippled/README.md
+++ b/docker/tools-rippled/README.md
@@ -63,7 +63,9 @@ registry.
 
 ```shell
 UBUNTU_VERSION=noble
+CMAKE_VERSION=3.31.6
 DOXYGEN_VERSION=1.9.8+ds-2build5
+GCC_VERSION=14
 GRAPHVIZ_VERSION=2.42.2-9ubuntu0.1
 CONTAINER_IMAGE=xrplf/ci/tools-rippled-documentation:latest
 
@@ -72,7 +74,9 @@ docker buildx build . \
   --target documentation \
   --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=InvalidDefaultArgInFrom \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg CMAKE_VERSION=${CMAKE_VERSION} \
   --build-arg DOXYGEN_VERSION=${DOXYGEN_VERSION} \
+  --build-arg GCC_VERSION=${GCC_VERSION} \
   --build-arg GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}


### PR DESCRIPTION
CMake and GCC are needed to build the documentation.