### PR TITLE
Add make to documentation image

### DIFF
--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -78,11 +78,12 @@ RUN python3 -m venv ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 RUN pip install --no-cache cmake==${CMAKE_VERSION}
 
-# Install GCC and create the necessary symlinks.
+# Install make, GCC and create the necessary symlinks.
 ARG GCC_VERSION
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends \
+  make \
   gcc-${GCC_VERSION} \
   g++-${GCC_VERSION}
 apt-get clean


### PR DESCRIPTION
Although I was able to build the `docs` target using a locally-created image, it complained in the CI pipeline.

```
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
```

This change adds `make` to resolve this issue.