### PR TITLE
Add IPC::Cmd perl package to RHEL

### DIFF
--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -20,6 +20,7 @@ pkgs+=(libstdc++-static)  # Required to statically link libraries into rippled.
 pkgs+=(ninja-build)       # Required build tool.
 pkgs+=(perl-FindBin)      # Required to compile OpenSSL.
 pkgs+=(perl-File-Compare) # Required to compile OpenSSL.
+pkgs+=(perl-IPC-Cmd)      # Required to compile OpenSSL.
 pkgs+=(python3.12)        # Required build tool.
 pkgs+=(python3.12-pip)    # Package manager for Python applications.
 pkgs+=(rpm-build)         # Required packaging tool.


### PR DESCRIPTION
To compile OpenSSL on RHEL, several Perl tools are needed. The one added in this PR addresses the error:

```
openssl/3.5.2: RUN: perl ./Configure "conan-Debug-Linux-x86_64-gcc-12" no-shared --debug --prefix=/ --libdir=lib --openssldir="/etc/ssl" threads PERL=perl no-unit-test no-tests -fPIC enable-fips no-md2 zlib --with-zlib-include="/root/.conan2/p/zlibb82dba1fbda07/p/include" --with-zlib-lib="/root/.conan2/p/zlibb82dba1fbda07/p/lib"
Can't locate IPC/Cmd.pm in @INC (you may need to install the IPC::Cmd module) (@INC contains: /root/.conan2/p/b/opens990704c062ae0/b/src/util/perl /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 /root/.conan2/p/b/opens990704c062ae0/b/src/external/perl/Text-Template-1.56/lib) at /root/.conan2/p/b/opens990704c062ae0/b/src/util/perl/OpenSSL/config.pm line 19.
BEGIN failed--compilation aborted at /root/.conan2/p/b/opens990704c062ae0/b/src/util/perl/OpenSSL/config.pm line 19.
Compilation failed in require at ./Configure line 23.
BEGIN failed--compilation aborted at ./Configure line 23.

openssl/3.5.2: ERROR: 
Package '55b963424a010a0e6d07b833636e438f6b5e9617' build failed
openssl/3.5.2: WARN: Build folder /root/.conan2/p/b/opens990704c062ae0/b/build-debug
ERROR: openssl/3.5.2: Error in build() method, line 535
	self._make()
while calling '_make', line 515
	self.run(f"{self._perl} ./Configure {args}", env="conanbuild")
	ConanException: Error 2 while executing
```