### PR TITLE
Combines clang-format and prettier into a single pre-commit image

### DIFF
--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -23,7 +23,7 @@ env:
   DOXYGEN_VERSION: 1.9.8+ds-2build5
   GCC_VERSION: 14
   GRAPHVIZ_VERSION: 2.42.2-9ubuntu0.1
-  NODE_VERSION: 24.6.0
+  NODE_VERSION: 24.5.0
   NPM_VERSION: 11.5.2
   PRETTIER_VERSION: 3.6.2
   PRE_COMMIT_VERSION: 4.2.0
@@ -39,9 +39,8 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
         tool:
-          - clang-format
           - documentation
-          - prettier
+          - pre-commit
     runs-on: ${{ matrix.architecture.runner }}
     permissions:
       packages: write
@@ -127,9 +126,8 @@ jobs:
     strategy:
       matrix:
         tool:
-          - clang-format
           - documentation
-          - prettier
+          - pre-commit
     runs-on: ubuntu-24.04
     needs:
       - build

--- a/docker/tools-rippled/Dockerfile
+++ b/docker/tools-rippled/Dockerfile
@@ -1,11 +1,5 @@
-# This argument must be defined before the base image, so it can be used in the
-# prettier image, which does not derive from the base image, below. We set both
-# the Node and Ubuntu versions to "undefined" to satisfy the syntax checker, as
-# it checks if the `FROM` command has a valid image, even when it is not used.
-ARG NODE_VERSION=undefined
-ARG UBUNTU_VERSION=undefined
-
 # ====================== BASE IMAGE ======================
+ARG UBUNTU_VERSION
 FROM ubuntu:${UBUNTU_VERSION} AS base
 
 # Use Bash as the default shell for RUN commands, using the options
@@ -52,20 +46,39 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 
-# ====================== CLANG-FORMAT IMAGE ======================
+# ====================== PRE-COMMIT IMAGE ======================
 # Note, we do not install a compiler here.
 
-FROM base AS clang-format
+FROM base AS pre-commit
 
 # This is not inherited from base image.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install clang-format.
+# Install clang-format and pre-commit.
 ARG CLANG_FORMAT_VERSION
 ARG PRE_COMMIT_VERSION
 RUN pip install --no-cache \
     clang-format==${CLANG_FORMAT_VERSION} \
     pre-commit==${PRE_COMMIT_VERSION}
+
+# Install Node.JS, NPM, and prettier.
+ARG NODE_VERSION
+ARG NPM_VERSION
+ARG PRETTIER_VERSION
+ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org
+RUN <<EOF
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+  gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION%%.*}.x nodistro main" | \
+ tee /etc/apt/sources.list.d/nodesource.list
+apt-get update
+apt-get install -y --no-install-recommends nodejs=${NODE_VERSION}-1nodesource1
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+npm install -g --no-audit --no-fund npm@${NPM_VERSION}
+npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
+npm cache clean --force
+EOF
 
 ENV HOME=/root
 WORKDIR ${HOME}
@@ -117,27 +130,6 @@ apt-get update
 apt-get install -y doxygen=${DOXYGEN_VERSION} graphviz=${GRAPHVIZ_VERSION}
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-EOF
-
-ENV HOME=/root
-WORKDIR ${HOME}
-
-# ====================== PRETTIER IMAGE ======================
-# Note, this image does not inherit from the base image.
-
-FROM node:${NODE_VERSION}-alpine AS prettier
-
-# Install bash and git.
-RUN apk add --no-cache bash git
-
-# Update NPM and install prettier.
-ARG NPM_VERSION
-ARG PRETTIER_VERSION
-ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org
-RUN <<EOF
-npm install -g --no-audit --no-fund npm@${NPM_VERSION}
-npm install -g --no-audit --no-fund prettier@${PRETTIER_VERSION}
-npm cache clean --force
 EOF
 
 ENV HOME=/root

--- a/docker/tools-rippled/README.md
+++ b/docker/tools-rippled/README.md
@@ -26,10 +26,14 @@ docker login ${CONTAINER_REGISTRY} -u "${GITHUB_USER}" --password-stdin
 
 Currently, this Dockerfile can be used to build one the following images:
 
-* `clang-format` with C++ formatting tools. This image requires parameters:
+* `pre-commit` with formatting tools for various languages. This image requires
+  parameters:
   * `UBUNTU_VERSION` for selecting the Ubuntu release (recommended `noble`).
   * `CLANG_FORMAT_VERSION` for the [clang-format](http://clang.llvm.org/docs/ClangFormat.html) version.
+  * `NODE_VERSION` for the [Node.js](https://nodejs.org/) version.
+  * `NPM_VERSION` for the [npm](https://www.npmjs.com/) version.
   * `PRE_COMMIT_VERSION` for the [pre-commit](https://pre-commit.com/) version.
+  * `PRETTIER_VERSION` for the [Prettier](https://prettier.io/) version.
 * `documentation` with tools for building the rippled documentation. This image
   requires parameters:
   * `UBUNTU_VERSION` for selecting the Ubuntu release (recommended `noble`)
@@ -37,16 +41,11 @@ Currently, this Dockerfile can be used to build one the following images:
   * `DOXYGEN_VERSION` for the [Doxygen](https://www.doxygen.nl/) version.
   * `GCC_VERSION` for the [GCC](https://gcc.gnu.org/) version.
   * `GRAPHVIZ_VERSION` for the [Graphviz](https://graphviz.org/) version.
-* `prettier` with tools for formatting JavaScript and TypeScript code. This
-  image requires parameters:
-  * `NODE_VERSION` for the [Node.js](https://nodejs.org/) version.
-  * `NPM_VERSION` for the [npm](https://www.npmjs.com/) version.
-  * `PRETTIER_VERSION` for the [Prettier](https://prettier.io/) version.
 
 In order to build an image, run the commands below from the root directory of
 the repository.
 
-#### Building the Docker image for clang-format
+#### Building the Docker image for pre-commit
 
 Ensure you've run the login command above to authenticate with the Docker
 registry.
@@ -54,16 +53,22 @@ registry.
 ```shell
 UBUNTU_VERSION=noble
 CLANG_FORMAT_VERSION=18.1.8
+NODE_VERSION=24.5.0
+NPM_VERSION=11.5.2
 PRE_COMMIT_VERSION=4.2.0
-CONTAINER_IMAGE=xrplf/ci/tools-rippled-clang-format:latest
+PRETTIER_VERSION=3.6.2
+CONTAINER_IMAGE=xrplf/ci/tools-rippled-pre-commit:latest
 
 docker buildx build . \
   --file docker/tools-rippled/Dockerfile \
-  --target clang-format \
+  --target pre-commit \
   --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=InvalidDefaultArgInFrom \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg CLANG_FORMAT_VERSION=${CLANG_FORMAT_VERSION} \
+  --build-arg NODE_VERSION=${NODE_VERSION} \
+  --build-arg NPM_VERSION=${NPM_VERSION} \
   --build-arg PRE_COMMIT_VERSION=${PRE_COMMIT_VERSION} \
+  --build-arg PRETTIER_VERSION=${PRETTIER_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
@@ -91,28 +96,6 @@ docker buildx build . \
   --build-arg GCC_VERSION=${GCC_VERSION} \
   --build-arg GRAPHVIZ_VERSION=${GRAPHVIZ_VERSION} \
   --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
-  --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
-```
-
-#### Building the Docker image for prettier
-
-Ensure you've run the login command above to authenticate with the Docker
-registry.
-
-```shell
-NODE_VERSION=24.6.0
-NPM_VERSION=11.5.2
-PRETTIER_VERSION=3.6.2
-CONTAINER_IMAGE=xrplf/ci/tools-rippled-prettier:latest
-
-docker buildx build . \
-  --file docker/tools-rippled/Dockerfile \
-  --target prettier \
-  --build-arg BUILDKIT_DOCKERFILE_CHECK=skip=InvalidDefaultArgInFrom \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg NODE_VERSION=${NODE_VERSION} \
-  --build-arg NPM_VERSION=${NPM_VERSION} \
-  --build-arg PRETTIER_VERSION=${PRETTIER_VERSION} \
   --tag ${CONTAINER_REGISTRY}/${CONTAINER_IMAGE}
 ```
 


### PR DESCRIPTION
This will allow us create a single pre-commit job that simply runs `pre-commit run --show-diff-on-failure --color=always --all-files`.

This change here uses Nodesource to install Node, instead of NVM - this time GitHub CI is able to run prettier without problems.