### PR TITLE
Add workflow_dispatch to the pipelines to set Docker image tag (suffix)

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -103,6 +103,14 @@ jobs:
             echo "CONTAINER_REPOSITORY_GCC=${CONTAINER_REPO}/debian-gcc" >> $GITHUB_ENV
             echo "CONTAINER_IMAGE_GCC=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/debian-gcc" >> $GITHUB_ENV
           fi
+      - name: Check if image already exists
+        if: ${{ env.CONTAINER_TAG != 'latest' }}
+        run: |
+          RET=$(docker manifest inspect ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }})
+          if [ ${RET} -eq 0 ]; then
+            echo 'Image ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }} already exists.'
+            exit 1
+          fi
       - name: Prepare gcc image metadata
         if: ${{ env.CONTAINER_IMAGE_GCC }}
         id: meta-gcc

--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -96,6 +96,14 @@ jobs:
           echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/rhel-${{ matrix.os.release }}" >> $GITHUB_ENV
           PLATFORM=${{ matrix.architecture.platform }}
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+      - name: Check if image already exists
+        if: ${{ env.CONTAINER_TAG != 'latest' }}
+        run: |
+          RET=$(docker manifest inspect ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }})
+          if [ ${RET} -eq 0 ]; then
+            echo 'Image ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }} already exists.'
+            exit 1
+          fi
       - name: Prepare container metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/tools-rippled.yml
+++ b/.github/workflows/tools-rippled.yml
@@ -68,6 +68,14 @@ jobs:
           echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/tools-rippled-${{ matrix.tool }}" >> $GITHUB_ENV
           PLATFORM=${{ matrix.architecture.platform }}
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+      - name: Check if image already exists
+        if: ${{ env.CONTAINER_TAG != 'latest' }}
+        run: |
+          RET=$(docker manifest inspect ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }})
+          if [ ${RET} -eq 0 ]; then
+            echo 'Image ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }} already exists.'
+            exit 1
+          fi
       - name: Prepare container metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -91,6 +91,14 @@ jobs:
           echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/ubuntu-${{ matrix.os.release }}" >> $GITHUB_ENV
           PLATFORM=${{ matrix.architecture.platform }}
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+      - name: Check if image already exists
+        if: ${{ env.CONTAINER_TAG != 'latest' }}
+        run: |
+          RET=$(docker manifest inspect ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }})
+          if [ ${RET} -eq 0 ]; then
+            echo 'Image ${{ env.CONTAINER_IMAGE }}:${{ env.CONTAINER_TAG }} already exists.'
+            exit 1
+          fi
       - name: Prepare container metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
To ensure reproducible builds and no surprises, we should be able to set the Docker image tags for the images we build and push.

This PR adds the `workflow_dispatch` to each of the four CI pipelines with a "tag" as input value. The workflow will then use that value as the Docker image tag suffix (for the distro images, which currently get the compiler name and version as tag) or as the image tag itself (for the tools image, which currently gets "latest" as tag).

Thus, before this change, e.g.:
* `debian-bookworm:gcc-15`
* `tools-rippled:latest`

After this change, e.g.
* `debian-bookworm:gcc-15-latest` (when merging a PR) and `debian-bookworm:gcc-15-v1.2.3` (when using workflow dispatch)
* `tools-rippled:latest` (when merging a PR) and `tools-rippled:v1.2.3` (when using workflow dispatch)