### PR TITLE
Add cleanup pipeline to remove unusable images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "42 2 * * 0" # Run every Sunday at 02:42 UTC.
   workflow_dispatch:
-  push:
 
 jobs:
   cleanup:
@@ -34,5 +33,4 @@ jobs:
           delete-orphaned-images: true
           delete-partial-images: true
           delete-untagged: true
-          dry-run: true
           package: ci/${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -24,7 +24,6 @@ jobs:
           image:
             - debian-bullseye
             - debian-bookworm
-            - debian-gcc
             - gcc
             - rhel-9.4
             - rhel-9.6

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,13 +12,18 @@ jobs:
     permissions:
       packages: write
     strategy:
+        fail-fast: false
         matrix:
           image:
             - debian-bullseye
             - debian-bookworm
+            - debian-gcc
             - rhel-9.4
             - rhel-9.6
-            - tools-rippled
+            - tools-rippled-clang-format
+            - tools-rippled-documentation
+            - tools-rippled-pre-commit
+            - tools-rippled-prettier
             - ubuntu-jammy
             - ubuntu-noble
     steps:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,6 +1,9 @@
 name: Docker image cleanup
 
 on:
+  push:
+    paths:
+      - .github/workflows/cleanup.yml
   schedule:
     - cron: "42 2 * * 0" # Run every Sunday at 02:42 UTC.
   workflow_dispatch:
@@ -27,10 +30,11 @@ jobs:
             - ubuntu-noble
     steps:
       - name: Cleanup images in the GitHub Container Registry
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           delete-ghost-images: true
           delete-orphaned-images: true
           delete-partial-images: true
           delete-untagged: true
+          dry-run: ${{ github.event_name == 'push' }}
           package: ci/${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,6 +25,7 @@ jobs:
             - debian-bullseye
             - debian-bookworm
             - debian-gcc
+            - gcc
             - rhel-9.4
             - rhel-9.6
             - tools-rippled-clang-format

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
         matrix:
           image:
-            - ci/debian-bullseye
-#            - debian-bookworm
-#            - rhel-9.4
-#            - rhel-9.6
-#            - tools-rippled
-#            - ubuntu-jammy
-#            - ubuntu-noble
+            - debian-bullseye
+            - debian-bookworm
+            - rhel-9.4
+            - rhel-9.6
+            - tools-rippled
+            - ubuntu-jammy
+            - ubuntu-noble
     steps:
       - name: Cleanup images in the GitHub Container Registry
         uses: dataaxiom/ghcr-cleanup-action@v1
@@ -30,4 +30,4 @@ jobs:
           delete-partial-images: true
           delete-untagged: true
           dry-run: true
-          package: ${{ matrix.image }}
+          package: ci/${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -30,4 +30,5 @@ jobs:
           delete-partial-images: true
           delete-untagged: true
           dry-run: true
+          repository: ${{ github.repository }}
           package: ${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,12 @@
 name: Docker image cleanup
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/cleanup.yml
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/cleanup.yml
   schedule:
@@ -36,5 +41,5 @@ jobs:
           delete-orphaned-images: true
           delete-partial-images: true
           delete-untagged: true
-          dry-run: ${{ github.event_name == 'push' }}
+          dry-run: ${{ github.event_name == 'pull_request' }}
           package: ci/${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,22 @@
+name: Docker image cleanup
+
+on:
+  schedule:
+    - cron: "42 2 * * 0" # Run every Sunday at 02:42 UTC.
+  workflow_dispatch:
+  push:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Cleanup images in the GitHub Container Registry
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-ghost-images: true
+          delete-orphaned-images: true
+          delete-partial-images: true
+          delete-untagged: true
+          dry-run: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
         matrix:
           image:
-            - debian-bullseye
+            - ci/debian-bullseye
 #            - debian-bookworm
 #            - rhel-9.4
 #            - rhel-9.6
@@ -30,5 +30,4 @@ jobs:
           delete-partial-images: true
           delete-untagged: true
           dry-run: true
-          repository: ${{ github.repository }}
           package: ${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,6 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    strategy:
+        matrix:
+          image:
+            - debian-bullseye
+#            - debian-bookworm
+#            - rhel-9.4
+#            - rhel-9.6
+#            - tools-rippled
+#            - ubuntu-jammy
+#            - ubuntu-noble
     steps:
       - name: Cleanup images in the GitHub Container Registry
         uses: dataaxiom/ghcr-cleanup-action@v1
@@ -20,4 +30,4 @@ jobs:
           delete-partial-images: true
           delete-untagged: true
           dry-run: true
-          packages: debian,rhel,tools-rippled,ubuntu
+          package: ${{ matrix.image }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,3 +20,4 @@ jobs:
           delete-partial-images: true
           delete-untagged: true
           dry-run: true
+          packages: debian,rhel,tools-rippled,ubuntu


### PR DESCRIPTION
This PR adds a weekly cleanup job to remove untagged, orphaned, ghost, and partial images.

I compared a few actions, and this one has seen the most recent development and offers many options to get rid of images.

Per the description at https://github.com/dataaxiom/ghcr-cleanup-action:
* delete-untagged = Delete all untagged images
* delete-ghost-images = Delete multi-architecture images where all underlying platform images are missing
* delete-partial-images = Delete multi-architecture images where some (but not all) underlying platform images are missing
* delete-orphaned-images = Delete tagged images which have no parent (e.g. referrers and cosign tags missing their parent)

I tested this workflow first by adding an `on: push` and enabling the dry-run option in the action, to confirm it was finding the correct images to delete.