### PR TITLE
Verify `ld.gold` is installed and show its version 

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -38,6 +38,7 @@ EOF
 RUN <<EOF
 pkgs=()
 pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+pkgs+=(binutils)        # Required build tools.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
 pkgs+=(debhelper)       # Required packaging tool.
@@ -58,6 +59,8 @@ apt-get install -y --no-install-recommends "${pkgs[@]}"
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
+
+RUN ld.gold --version
 
 # Install Python-based tools and cmake.
 ARG CONAN_VERSION

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -12,6 +12,7 @@ ENTRYPOINT ["/bin/bash"]
 RUN <<EOF
 pkgs=()
 pkgs+=(ca-certificates)   # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+pkgs+=(binutils-gold)     # Required build tool.
 pkgs+=(file)              # Required packaging tool.
 pkgs+=(git)               # Required build tool.
 pkgs+=(gpg)               # Dependency for tools requiring signing or encrypting/decrypting.
@@ -51,6 +52,8 @@ ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
 mkdir -p /usr/local/lib
 ln -sf /usr/lib/python3.12 /usr/local/lib/python3.12
 EOF
+
+RUN ld.gold --version
 
 # Install Python-based tools and cmake.
 ARG CONAN_VERSION

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -26,6 +26,7 @@ EOF
 RUN <<EOF
 pkgs=()
 pkgs+=(ca-certificates) # Enable TLS verification for HTTPS connections by providing trusted root certificates.
+pkgs+=(binutils)        # Required build tools.
 pkgs+=(curl)            # Dependency for tools requiring downloading data.
 pkgs+=(dpkg-dev)        # Required packaging tool.
 pkgs+=(file)            # Required packaging tool.
@@ -45,6 +46,8 @@ apt-get install -y --no-install-recommends "${pkgs[@]}"
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
+
+RUN ld.gold --version
 
 # Install Python-based tools and cmake.
 ARG CONAN_VERSION


### PR DESCRIPTION
This does not actually add `ld.gold` to our docker images (since `binutils` are a required dependency anyway), however it does make it explicit and shows its version. Might be also useful for the future, if `ld.gold` is no longer installed by default (we will know to add it because the pipelines will start failing).