### PR TITLE
Only build RHEL images for major versions

### DIFF
--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -28,12 +28,8 @@ env:
 
 jobs:
   # Build the Docker image for Red Hat Enterprise Linux using different versions
-  # of GCC. Note, the `os` part of matrix must be kept in sync with the `merge`
-  # job below. Also note that we only push images for the major version of RHEL
-  # but the UBI images require a valid minor version to also be provided, e.g.
-  #  release=9.6 + compiler_name=gcc + compiler_version=14 (matrix) ->
-  #  ubi:9.6 + gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ (Dockerfile) ->
-  #  rhel-9:gcc-14 (our image).
+  # of GCC
+  # Note, the `os` part of matrix must be kept in sync with the `merge` job below
   build:
     strategy:
       matrix:
@@ -43,16 +39,16 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
         os:
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 12
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 13
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 14
-          - release: 9.6
+          - release: 9
             compiler_name: clang
             compiler_version: 'any'
     runs-on: ${{ matrix.architecture.runner }}
@@ -82,10 +78,8 @@ jobs:
           # still does not provide convenient action expression syntax for lowercase.
           GITHUB_REPO=${{ github.repository }}
           CONTAINER_REPO=${GITHUB_REPO@L}
-          RHEL_VERSION=${{ matrix.os.release }}
-          MAJOR_VERSION=${RHEL_VERSION%%.*}
-          echo "CONTAINER_REPOSITORY=${CONTAINER_REPO}/rhel-${MAJOR_VERSION}" >> $GITHUB_ENV
-          echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/rhel-${MAJOR_VERSION}" >> $GITHUB_ENV
+          echo "CONTAINER_REPOSITORY=${CONTAINER_REPO}/rhel-${{ matrix.os.release }}" >> $GITHUB_ENV
+          echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/rhel-${{ matrix.os.release }}" >> $GITHUB_ENV
           PLATFORM=${{ matrix.architecture.platform }}
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
       - name: Prepare container metadata
@@ -145,16 +139,16 @@ jobs:
     strategy:
       matrix:
         os:
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 12
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 13
-          - release: 9.6
+          - release: 9
             compiler_name: gcc
             compiler_version: 14
-          - release: 9.6
+          - release: 9
             compiler_name: clang
             compiler_version: 'any'
     runs-on: ubuntu-24.04
@@ -183,9 +177,7 @@ jobs:
         run: |
           GITHUB_REPO=${{ github.repository }}
           CONTAINER_REPO=${GITHUB_REPO@L}
-          RHEL_VERSION=${{ matrix.os.release }}
-          MAJOR_VERSION=${RHEL_VERSION%%.*}
-          echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/rhel-${MAJOR_VERSION}" >> $GITHUB_ENV
+          echo "CONTAINER_IMAGE=${CONTAINER_REGISTRY}/${CONTAINER_REPO}/rhel-${{ matrix.os.release }}" >> $GITHUB_ENV
       - name: Prepare container metadata
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0

--- a/docker/rhel/Dockerfile
+++ b/docker/rhel/Dockerfile
@@ -1,7 +1,7 @@
 # ====================== BASE IMAGE ======================
 ARG RHEL_VERSION
 
-FROM registry.redhat.io/ubi${RHEL_VERSION%%.*}/ubi:${RHEL_VERSION} AS base
+FROM registry.redhat.io/ubi${RHEL_VERSION}/ubi:latest AS base
 
 # Use Bash as the default shell for RUN commands, using the options
 # `set -o errexit -o pipefail`, and as the entrypoint.

--- a/docker/rhel/README.md
+++ b/docker/rhel/README.md
@@ -60,13 +60,13 @@ Ensure you've run the login command above to authenticate with the Docker
 registry.
 
 ```shell
-RHEL_VERSION=9.6
+RHEL_VERSION=9
 GCC_VERSION=13
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
 CMAKE_VERSION=3.31.6
 MOLD_VERSION=2.40.4
-CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION%%.*}:gcc-${GCC_VERSION}
+CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:gcc-${GCC_VERSION}
 
 docker buildx build . \
   --file docker/rhel/Dockerfile \
@@ -88,12 +88,12 @@ Ensure you've run the login command above to authenticate with the Docker
 registry.
 
 ```shell
-RHEL_VERSION=9.6
+RHEL_VERSION=9
 CONAN_VERSION=2.19.1
 GCOVR_VERSION=8.3
 CMAKE_VERSION=3.31.6
 MOLD_VERSION=2.40.4
-CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION%%.*}:clang-any
+CONTAINER_IMAGE=xrplf/ci/rhel-${RHEL_VERSION}:clang-any
 
 docker buildx build . \
   --file docker/rhel/Dockerfile \


### PR DESCRIPTION
As `dnf update` will update RHEL to the latest minor version, unless we add workarounds (see https://github.com/XRPLF/ci/pull/57), we can take ABI compatibility within a major release for granted. To reduce our maintenance burden, this PR now only builds images using the latest RHEL 9 version, currently 9.6. This will also reduce our computational expenses as we will no longer need to build rippled using `rhel-9.4:clang-any` and `rhel-9.6:clang-any`, but only using `rhel-9:clang-any`.