### PR TITLE
Install clang-tidy on debian only for clang-21

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -73,6 +73,9 @@ jobs:
           - release: noble
             compiler_name: clang
             compiler_version: 20
+          - release: noble
+            compiler_name: clang
+            compiler_version: 21
     runs-on: ${{ matrix.architecture.runner }}
     permissions:
       packages: write
@@ -183,6 +186,9 @@ jobs:
           - release: noble
             compiler_name: clang
             compiler_version: 20
+          - release: noble
+            compiler_name: clang
+            compiler_version: 21
     runs-on: ubuntu-24.04
     needs:
       - build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -73,9 +73,6 @@ jobs:
           - release: noble
             compiler_name: clang
             compiler_version: 20
-          - release: noble
-            compiler_name: clang
-            compiler_version: 21
     runs-on: ${{ matrix.architecture.runner }}
     permissions:
       packages: write
@@ -186,9 +183,6 @@ jobs:
           - release: noble
             compiler_name: clang
             compiler_version: 20
-          - release: noble
-            compiler_name: clang
-            compiler_version: 21
     runs-on: ubuntu-24.04
     needs:
       - build

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -267,6 +267,14 @@ apt-get install -t llvm-toolchain-${DEBIAN_VERSION}-${CLANG_VERSION} -y --no-ins
   clang-${CLANG_VERSION} \
   libclang-rt-${CLANG_VERSION}-dev \
   llvm-${CLANG_VERSION}
+if [[ "${CLANG_VERSION}" -eq 21 ]]; then
+  apt-get install -y --no-install-recommends --allow-unauthenticated \
+    clang-tidy-${CLANG_VERSION}
+  update-alternatives \
+    --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${CLANG_VERSION} 100
+  update-alternatives \
+    --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-${CLANG_VERSION} 100
+fi
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 update-alternatives \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -228,6 +228,16 @@ printf "%s\n" \
   "Acquire::AllowWeakRepositories \"true\";" \
   | tee /etc/apt/apt.conf.d/99llvm-allow-weak
 
+# Add LLVM repository for versions above 20 because it is not available in the default repo
+if [[ "${CLANG_VERSION}" -gt 20 ]]; then
+  apt-get update
+  apt-get install -y --no-install-recommends lsb-release software-properties-common gnupg
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+  DISTRO_CODENAME=$(lsb_release -cs)
+  echo "deb http://apt.llvm.org/${DISTRO_CODENAME}/ llvm-toolchain-${DISTRO_CODENAME}-${CLANG_VERSION} main" \
+    | tee /etc/apt/sources.list.d/llvm.list
+fi
+
 apt-get update
 apt-get install -y --no-install-recommends --allow-unauthenticated \
   clang-${CLANG_VERSION} \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -228,25 +228,6 @@ printf "%s\n" \
   "Acquire::AllowWeakRepositories \"true\";" \
   | tee /etc/apt/apt.conf.d/99llvm-allow-weak
 
-if [[ "${CLANG_VERSION}" -eq 21 ]]; then
-  apt-get update
-    # Add LLVM repository for versions above 20 because it is not available in the default repo
-  apt-get install -y --no-install-recommends lsb-release software-properties-common gnupg
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-  DISTRO_CODENAME=$(lsb_release -cs)
-  echo "deb http://apt.llvm.org/${DISTRO_CODENAME}/ llvm-toolchain-${DISTRO_CODENAME}-${CLANG_VERSION} main" \
-    | tee /etc/apt/sources.list.d/llvm.list
-  apt-get update
-  apt-get install -y --no-install-recommends --allow-unauthenticated \
-    clang-tidy-${CLANG_VERSION}
-  update-alternatives \
-    --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${CLANG_VERSION} 100
-  update-alternatives \
-    --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-${CLANG_VERSION} 100
-  apt-get clean
-  rm -rf /var/lib/apt/lists/*
-fi
-
 apt-get update
 apt-get install -y --no-install-recommends --allow-unauthenticated \
   clang-${CLANG_VERSION} \


### PR DESCRIPTION
I found that we already have clang-21 in debian image, so it makes more sense to install clang-tidy there instead of introducing a new image.